### PR TITLE
fix(slack): threads

### DIFF
--- a/spec/autobot/agent/loop_spec.cr
+++ b/spec/autobot/agent/loop_spec.cr
@@ -216,6 +216,29 @@ describe Autobot::Agent::Loop do
     ensure
       FileUtils.rm_rf(tmp) if tmp
     end
+
+    it "preserves inbound metadata in outbound response" do
+      tmp = TestHelper.tmp_dir
+      loop_inst = create_test_loop(workspace: tmp)
+
+      msg = Autobot::Bus::InboundMessage.new(
+        channel: "slack",
+        sender_id: "U12345",
+        chat_id: "C67890",
+        content: "Hello from Slack",
+        metadata: {
+          "thread_ts"    => "1234567890.123456",
+          "channel_type" => "channel",
+        },
+      )
+
+      response = loop_inst.test_process_message(msg)
+      response.should_not be_nil
+      response.try(&.metadata["thread_ts"]).should eq("1234567890.123456")
+      response.try(&.metadata["channel_type"]).should eq("channel")
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
   end
 
   describe "message tool wiring" do

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -164,7 +164,7 @@ module Autobot::Agent
       save_to_session(session, msg.content, final_content, tools_used)
 
       # Build and return response
-      build_response(msg.channel, msg.chat_id, final_content)
+      build_response(msg.channel, msg.chat_id, final_content, msg.metadata)
     end
 
     # Process a system message (e.g., subagent announcement).
@@ -395,14 +395,15 @@ module Autobot::Agent
     end
 
     # Build outbound message with logging
-    private def build_response(channel : String, chat_id : String, content : String) : Bus::OutboundMessage
+    private def build_response(channel : String, chat_id : String, content : String, metadata : Hash(String, String) = {} of String => String) : Bus::OutboundMessage
       preview = content.size > LONG_MESSAGE_PREVIEW_LENGTH ? content[0..LONG_MESSAGE_PREVIEW_LENGTH] + "..." : content
       Log.info { "Response: #{preview}" }
 
       Bus::OutboundMessage.new(
         channel: channel,
         chat_id: chat_id,
-        content: content
+        content: content,
+        metadata: metadata,
       )
     end
 


### PR DESCRIPTION
The bug was in agent/loop.cr — build_response was creating OutboundMessage without passing through the inbound message's metadata. The thread_ts and channel_type from the Slack event were lost, so the reply always went to the channel instead of the thread.

Fixed by passing msg.metadata through to build_response → OutboundMessage. Rebuild and try mentioning the bot in a channel — it should reply in a thread now.