### PR TITLE
fix(channels): refactoring, re-use contants

### DIFF
--- a/spec/autobot/channels/zulip_spec.cr
+++ b/spec/autobot/channels/zulip_spec.cr
@@ -1,0 +1,80 @@
+require "../../spec_helper"
+
+# Expose private methods for testing via a thin subclass.
+class ZulipChannelTest < Autobot::Channels::ZulipChannel
+  def test_access_denied_message(sender_id : String) : String
+    access_denied_message(sender_id)
+  end
+
+  def test_process_event(event : JSON::Any)
+    process_event(event)
+  end
+end
+
+private def build_channel(
+  allow_from : Array(String) = [] of String,
+) : ZulipChannelTest
+  bus = Autobot::Bus::MessageBus.new
+  ZulipChannelTest.new(
+    bus: bus,
+    site: "https://zulip.example.com",
+    email: "bot@example.com",
+    api_key: "test-api-key",
+    allow_from: allow_from,
+  )
+end
+
+describe Autobot::Channels::ZulipChannel do
+  describe "#access_denied_message" do
+    it "shows setup instructions when allow_from is empty" do
+      channel = build_channel(allow_from: [] of String)
+      msg = channel.test_access_denied_message("user@example.com")
+
+      msg.should contain("no authorized users yet")
+      msg.should contain("allow_from")
+      msg.should contain("config.yml")
+      msg.should contain("user@example.com")
+    end
+
+    it "shows generic denial when allow_from has entries" do
+      channel = build_channel(allow_from: ["allowed@example.com"])
+      msg = channel.test_access_denied_message("other@example.com")
+
+      msg.should contain("Access denied")
+      msg.should contain("not in the authorized users list")
+      msg.should_not contain("config.yml")
+    end
+
+    it "uses Markdown backticks instead of HTML code tags" do
+      channel = build_channel(allow_from: [] of String)
+      msg = channel.test_access_denied_message("user@example.com")
+
+      msg.should contain("`allow_from`")
+      msg.should contain("`user@example.com`")
+      msg.should_not contain("<code>")
+      msg.should_not contain("</code>")
+    end
+  end
+
+  describe "#allowed?" do
+    it "denies when allow_from is empty" do
+      channel = build_channel(allow_from: [] of String)
+      channel.allowed?("user@example.com").should be_false
+    end
+
+    it "allows matching email" do
+      channel = build_channel(allow_from: ["user@example.com"])
+      channel.allowed?("user@example.com").should be_true
+    end
+
+    it "allows wildcard *" do
+      channel = build_channel(allow_from: ["*"])
+      channel.allowed?("anyone@example.com").should be_true
+    end
+
+    it "denies non-matching email" do
+      channel = build_channel(allow_from: ["allowed@example.com"])
+      channel.allowed?("other@example.com").should be_false
+    end
+  end
+end

--- a/src/autobot/channels/manager.cr
+++ b/src/autobot/channels/manager.cr
@@ -2,6 +2,8 @@ require "./base"
 require "./telegram"
 require "./slack"
 require "./whatsapp"
+require "./zulip"
+require "../constants"
 require "../config/schema"
 require "../bus/queue"
 require "../cron/service"
@@ -118,7 +120,7 @@ module Autobot::Channels
       return unless config && config.enabled?
 
       custom_cmds = config.custom_commands || Config::CustomCommandsConfig.from_yaml("{}")
-      @channels["telegram"] = TelegramChannel.new(
+      @channels[Constants::CHANNEL_TELEGRAM] = TelegramChannel.new(
         bus: @bus,
         token: config.token,
         allow_from: config.allow_from,
@@ -135,7 +137,7 @@ module Autobot::Channels
       return unless config && config.enabled?
 
       dm_cfg = config.dm || Config::SlackDMConfig.from_yaml("{}")
-      @channels["slack"] = SlackChannel.new(
+      @channels[Constants::CHANNEL_SLACK] = SlackChannel.new(
         bus: @bus,
         bot_token: config.bot_token,
         app_token: config.app_token,
@@ -150,7 +152,7 @@ module Autobot::Channels
     private def init_whatsapp(config)
       return unless config && config.enabled?
 
-      @channels["whatsapp"] = WhatsAppChannel.new(
+      @channels[Constants::CHANNEL_WHATSAPP] = WhatsAppChannel.new(
         bus: @bus,
         bridge_url: config.bridge_url,
         allow_from: config.allow_from,
@@ -161,7 +163,7 @@ module Autobot::Channels
     private def init_zulip(config)
       return unless config && config.enabled?
 
-      @channels["zulip"] = ZulipChannel.new(
+      @channels[Constants::CHANNEL_ZULIP] = ZulipChannel.new(
         bus: @bus,
         site: config.site,
         email: config.email,

--- a/src/autobot/channels/slack.cr
+++ b/src/autobot/channels/slack.cr
@@ -33,7 +33,7 @@ module Autobot::Channels
       @group_allow_from : Array(String) = [] of String,
       @dm_config : Config::SlackDMConfig = Config::SlackDMConfig.new,
     )
-      super("slack", @bus, allow_from)
+      super(Constants::CHANNEL_SLACK, @bus, allow_from)
     end
 
     def start : Nil

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -4,6 +4,7 @@ require "http_proxy"
 require "json"
 require "uri"
 require "./base"
+require "../constants"
 require "../cron/formatter"
 require "../cron/service"
 
@@ -215,7 +216,7 @@ module Autobot::Channels
       @transcriber : Transcriber? = nil,
       @cron_service : Cron::Service? = nil,
     )
-      super("telegram", @bus, @allow_from)
+      super(Constants::CHANNEL_TELEGRAM, @bus, @allow_from)
     end
 
     def start : Nil
@@ -553,7 +554,7 @@ module Autobot::Channels
         return
       end
 
-      jobs = cron.list_jobs(owner: Cron.owner_key("telegram", chat_id))
+      jobs = cron.list_jobs(owner: Cron.owner_key(Constants::CHANNEL_TELEGRAM, chat_id))
 
       if jobs.empty?
         send_reply(chat_id, "No scheduled jobs.\n\nAsk me in chat to schedule something.")

--- a/src/autobot/channels/whatsapp.cr
+++ b/src/autobot/channels/whatsapp.cr
@@ -1,6 +1,7 @@
 require "http/web_socket"
 require "json"
 require "./base"
+require "../constants"
 
 module Autobot::Channels
   # WhatsApp channel that connects to a Node.js bridge.
@@ -26,7 +27,7 @@ module Autobot::Channels
       @bridge_url : String = "ws://localhost:3001",
       @allow_from : Array(String) = [] of String,
     )
-      super("whatsapp", @bus, @allow_from)
+      super(Constants::CHANNEL_WHATSAPP, @bus, @allow_from)
     end
 
     def start : Nil

--- a/src/autobot/channels/zulip.cr
+++ b/src/autobot/channels/zulip.cr
@@ -1,6 +1,7 @@
 require "crest"
 require "json"
 require "./base"
+require "../constants"
 
 module Autobot::Channels
   # Zulip channel using Real-time Events API (Long Polling).
@@ -27,7 +28,7 @@ module Autobot::Channels
       @api_key : String,
       allow_from : Array(String) = [] of String,
     )
-      super("zulip", bus, allow_from)
+      super(Constants::CHANNEL_ZULIP, bus, allow_from)
       @site = @site.rstrip('/')
     end
 
@@ -66,8 +67,8 @@ module Autobot::Channels
     private def access_denied_message(sender_id : String) : String
       if @allow_from.empty?
         "This bot has no authorized users yet.\n" \
-        "Add your user ID to <code>allow_from</code> in config.yml to get started.\n\n" \
-        "Your ID: <code>#{sender_id}</code>"
+        "Add your user ID to `allow_from` in config.yml to get started.\n\n" \
+        "Your ID: `#{sender_id}`"
       else
         "Access denied. You are not in the authorized users list."
       end
@@ -165,7 +166,7 @@ module Autobot::Channels
 
       unless allowed?(sender_email)
         Log.warn { "Access denied for sender #{sender_email} on zulip. Add to allow_from to grant access." }
-        send_message(Bus::OutboundMessage.new("zulip", sender_email, access_denied_message(sender_email)))
+        send_message(Bus::OutboundMessage.new(Constants::CHANNEL_ZULIP, sender_email, access_denied_message(sender_email)))
         return
       end
       Log.debug { "Zulip DM from #{sender_email}: #{content}" }

--- a/src/autobot/cli/config_generator.cr
+++ b/src/autobot/cli/config_generator.cr
@@ -1,3 +1,5 @@
+require "../constants"
+
 module Autobot
   module CLI
     # Generates configuration files from setup data
@@ -25,11 +27,11 @@ module Autobot
 
       private def self.generate_channel_env(channel : String, config : InteractiveSetup::Configuration, lines : Array(String))
         case channel
-        when "telegram"
+        when Constants::CHANNEL_TELEGRAM
           generate_telegram_env(config, lines)
-        when "slack"
+        when Constants::CHANNEL_SLACK
           generate_slack_env(config, lines)
-        when "zulip"
+        when Constants::CHANNEL_ZULIP
           generate_zulip_env(config, lines)
         end
       end
@@ -139,24 +141,24 @@ module Autobot
         lines = [] of String
 
         case channel
-        when "telegram"
+        when Constants::CHANNEL_TELEGRAM
           lines << "  telegram:"
           lines << "    enabled: true"
           lines << "    token: \"${TELEGRAM_BOT_TOKEN}\""
           lines << "    allow_from: []  # Add Telegram user IDs to enable"
-        when "slack"
+        when Constants::CHANNEL_SLACK
           lines << "  slack:"
           lines << "    enabled: true"
           lines << "    bot_token: \"${SLACK_BOT_TOKEN}\""
           lines << "    app_token: \"${SLACK_APP_TOKEN}\""
           lines << "    mode: \"socket\""
           lines << "    group_policy: \"mention\""
-        when "whatsapp"
+        when Constants::CHANNEL_WHATSAPP
           lines << "  whatsapp:"
           lines << "    enabled: true"
           lines << "    bridge_url: \"#{config.whatsapp_bridge_url || "ws://localhost:3001"}\""
           lines << "    allow_from: []  # Add phone numbers to enable"
-        when "zulip"
+        when Constants::CHANNEL_ZULIP
           lines << "  zulip:"
           lines << "    enabled: true"
           lines << "    site: \"${ZULIP_SITE}\""

--- a/src/autobot/cli/interactive_setup.cr
+++ b/src/autobot/cli/interactive_setup.cr
@@ -1,3 +1,5 @@
+require "../constants"
+
 module Autobot
   module CLI
     # Interactive configuration setup for new bot instances
@@ -15,10 +17,10 @@ module Autobot
 
       # Supported chat channels
       CHANNELS = {
-        "telegram" => "Telegram",
-        "slack"    => "Slack",
-        "whatsapp" => "WhatsApp",
-        "zulip"    => "Zulip",
+        Constants::CHANNEL_TELEGRAM => "Telegram",
+        Constants::CHANNEL_SLACK    => "Slack",
+        Constants::CHANNEL_WHATSAPP => "WhatsApp",
+        Constants::CHANNEL_ZULIP    => "Zulip",
       }
 
       # Configuration collected from user
@@ -215,13 +217,13 @@ module Autobot
       # Prompts for channel-specific configuration
       def self.prompt_channel_config(channel : String, config : Configuration, input : IO, output : IO)
         case channel
-        when "telegram"
+        when Constants::CHANNEL_TELEGRAM
           prompt_telegram_config(config, input, output)
-        when "slack"
+        when Constants::CHANNEL_SLACK
           prompt_slack_config(config, input, output)
-        when "whatsapp"
+        when Constants::CHANNEL_WHATSAPP
           prompt_whatsapp_config(config, input, output)
-        when "zulip"
+        when Constants::CHANNEL_ZULIP
           prompt_zulip_config(config, input, output)
         end
       end


### PR DESCRIPTION
1. Refactored 7 files to use Constants::CHANNEL_* instead of string literals:
  - telegram.cr — super() and Cron.owner_key() calls
  - slack.cr — super() call
  - whatsapp.cr — super() call
  - zulip.cr — super() and Bus::OutboundMessage.new() calls
  - manager.cr — all @channels[...] hash keys + added missing require "./zulip"
  - interactive_setup.cr — CHANNELS hash keys and case/when branches
  - config_generator.cr — both case/when blocks

  2. Fixed access_denied_message in Zulip — replaced `<code>` HTML tags with Markdown backticks, since Zulip uses Markdown, not HTML.

  3. Added spec/autobot/channels/zulip_spec.cr with 7 test cases covering:
  - #access_denied_message — setup instructions, generic denial, backtick formatting
  - #allowed? — empty list denial, matching email, wildcard *, non-matching email