### PR TITLE
fix(provider): implement retry logic for 429 and 5xx errors

### DIFF
--- a/spec/autobot/providers/http_provider_spec.cr
+++ b/spec/autobot/providers/http_provider_spec.cr
@@ -7,9 +7,6 @@ class TestableHttpProvider < Autobot::Providers::HttpProvider
   property call_count = 0
   property responses = [] of HTTP::Client::Response
 
-  # Set retry delay to 0 for instant tests
-  INITIAL_RETRY_DELAY = 0.seconds
-
   def test_strip_provider_prefix(model : String) : String
     strip_provider_prefix(model)
   end
@@ -39,15 +36,17 @@ class TestableHttpProvider < Autobot::Providers::HttpProvider
     max_tokens_param_name(model, spec)
   end
 
-  private def do_http_post(host, port, tls, path, headers, body) : HTTP::Client::Response
+  private def initial_retry_delay : Time::Span
+    0.seconds
+  end
+
+  private def do_http_post(client : HTTP::Client, path : String, headers : HTTP::Headers, body : String) : HTTP::Client::Response
     @call_count += 1
     parsed = JSON.parse(body)
     @last_api_model = parsed["model"]?.try(&.as_s?)
     @last_api_body = parsed
 
-    if !@responses.empty?
-      return @responses.shift
-    end
+    return @responses.shift unless @responses.empty?
 
     # Return a minimal valid response based on the path
     if path.includes?("/messages")

--- a/spec/autobot/providers/http_provider_spec.cr
+++ b/spec/autobot/providers/http_provider_spec.cr
@@ -492,7 +492,11 @@ describe Autobot::Providers::HttpProvider do
 
       response = provider.chat(messages)
       response.finish_reason.should eq("error")
-      response.content.not_nil!.should contain("Final Err")
+      if content = response.content
+        content.should contain("Final Err")
+      else
+        fail("Expected content to not be nil")
+      end
       provider.call_count.should eq(4)
     end
   end

--- a/spec/autobot/providers/http_provider_spec.cr
+++ b/spec/autobot/providers/http_provider_spec.cr
@@ -4,6 +4,11 @@ require "../../spec_helper"
 class TestableHttpProvider < Autobot::Providers::HttpProvider
   getter last_api_model : String?
   getter last_api_body : JSON::Any?
+  property call_count = 0
+  property responses = [] of HTTP::Client::Response
+
+  # Set retry delay to 0 for instant tests
+  INITIAL_RETRY_DELAY = 0.seconds
 
   def test_strip_provider_prefix(model : String) : String
     strip_provider_prefix(model)
@@ -34,12 +39,18 @@ class TestableHttpProvider < Autobot::Providers::HttpProvider
     max_tokens_param_name(model, spec)
   end
 
-  private def http_post(url : String, headers : HTTP::Headers, body : String) : HTTP::Client::Response
+  private def do_http_post(host, port, tls, path, headers, body) : HTTP::Client::Response
+    @call_count += 1
     parsed = JSON.parse(body)
     @last_api_model = parsed["model"]?.try(&.as_s?)
     @last_api_body = parsed
-    # Return a minimal valid response based on the URL
-    if url.includes?("/messages")
+
+    if !@responses.empty?
+      return @responses.shift
+    end
+
+    # Return a minimal valid response based on the path
+    if path.includes?("/messages")
       HTTP::Client::Response.new(200, body: %({"type":"message","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":0,"output_tokens":0}}))
     else
       HTTP::Client::Response.new(200, body: %({"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}))
@@ -438,6 +449,51 @@ describe Autobot::Providers::HttpProvider do
       arr[1]["type"].as_s.should eq("image")
       arr[1]["source"]["media_type"].as_s.should eq("image/png")
       arr[1]["source"]["data"].as_s.should eq("cG5nZGF0YQ==")
+    end
+  end
+
+  describe "retry logic" do
+    messages = [{"role" => JSON::Any.new("user"), "content" => JSON::Any.new("hi")}]
+
+    it "retries on 429 Rate Limit" do
+      provider = TestableHttpProvider.new(api_key: "key", model: "gpt-4")
+      provider.responses = [
+        HTTP::Client::Response.new(429, body: %({"error":{"message":"Rate limit reached"}})),
+        HTTP::Client::Response.new(200, body: %({"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}})),
+      ]
+
+      response = provider.chat(messages)
+      response.content.should eq("ok")
+      provider.call_count.should eq(2)
+    end
+
+    it "retries on 5xx Server Error" do
+      provider = TestableHttpProvider.new(api_key: "key", model: "gpt-4")
+      provider.responses = [
+        HTTP::Client::Response.new(503, body: %({"error":{"message":"Service Unavailable"}})),
+        HTTP::Client::Response.new(500, body: %({"error":{"message":"Internal Server Error"}})),
+        HTTP::Client::Response.new(200, body: %({"choices":[{"message":{"content":"success"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}})),
+      ]
+
+      response = provider.chat(messages)
+      response.content.should eq("success")
+      provider.call_count.should eq(3)
+    end
+
+    it "eventually fails after max retries" do
+      provider = TestableHttpProvider.new(api_key: "key", model: "gpt-4")
+      # 4 calls total: initial + 3 retries
+      provider.responses = [
+        HTTP::Client::Response.new(429, body: %({"error":{"message":"Err 1"}})),
+        HTTP::Client::Response.new(429, body: %({"error":{"message":"Err 2"}})),
+        HTTP::Client::Response.new(429, body: %({"error":{"message":"Err 3"}})),
+        HTTP::Client::Response.new(429, body: %({"error":{"message":"Final Err"}})),
+      ]
+
+      response = provider.chat(messages)
+      response.finish_reason.should eq("error")
+      response.content.not_nil!.should contain("Final Err")
+      provider.call_count.should eq(4)
     end
   end
 end

--- a/src/autobot/providers/http_provider.cr
+++ b/src/autobot/providers/http_provider.cr
@@ -610,12 +610,8 @@ module Autobot
         retry_delay = INITIAL_RETRY_DELAY
 
         (0..MAX_RETRIES).each do |attempt|
-          client = HTTP::Client.new(host, port: uri.port, tls: tls)
-          client.connect_timeout = CONNECT_TIMEOUT
-          client.read_timeout = READ_TIMEOUT
-
           begin
-            response = client.post(path, headers: headers, body: body)
+            response = do_http_post(host, uri.port, tls, path, headers, body)
             last_response = response
 
             if response.success?
@@ -643,12 +639,21 @@ module Autobot
             else
               raise ex
             end
-          ensure
-            client.close
           end
         end
 
         last_response || raise "HTTP request failed without response"
+      end
+
+      private def do_http_post(host, port, tls, path, headers, body) : HTTP::Client::Response
+        client = HTTP::Client.new(host, port: port, tls: tls)
+        client.connect_timeout = CONNECT_TIMEOUT
+        client.read_timeout = READ_TIMEOUT
+        begin
+          client.post(path, headers: headers, body: body)
+        ensure
+          client.close
+        end
       end
     end
   end

--- a/src/autobot/providers/http_provider.cr
+++ b/src/autobot/providers/http_provider.cr
@@ -20,7 +20,7 @@ module Autobot
       USER_AGENT            = "Autobot/#{VERSION}"
       ANTHROPIC_API_VERSION = "2023-06-01"
 
-      MAX_RETRIES          = 3
+      MAX_RETRIES         = 3
       INITIAL_RETRY_DELAY = 2.seconds
 
       getter model : String

--- a/src/autobot/providers/http_provider.cr
+++ b/src/autobot/providers/http_provider.cr
@@ -22,6 +22,9 @@ module Autobot
 
       MAX_RETRIES         = 3
       INITIAL_RETRY_DELAY = 2.seconds
+      RATE_LIMIT_STATUS   = 429
+      SERVER_ERROR_MIN    = 500
+      SERVER_ERROR_MAX    = 599
 
       getter model : String
       getter extra_headers : Hash(String, String)
@@ -606,54 +609,64 @@ module Autobot
         raise "Invalid URL: missing host in '#{url}'" unless host
 
         path = uri.request_target
-        last_response : HTTP::Client::Response? = nil
-        retry_delay = INITIAL_RETRY_DELAY
+        retry_delay = initial_retry_delay
+        client = build_http_client(host, uri.port, tls)
 
         (0..MAX_RETRIES).each do |attempt|
           begin
-            response = do_http_post(host, uri.port, tls, path, headers, body)
-            last_response = response
+            response = do_http_post(client, path, headers, body)
 
             if response.success?
               Log.debug { "Response #{response.status_code} (#{response.body.size} bytes)" }
               return response
             end
 
-            # Retry on rate limits (429) or server errors (5xx)
-            should_retry = response.status_code == 429 || (response.status_code >= 500 && response.status_code <= 599)
-
-            if should_retry && attempt < MAX_RETRIES
+            if retryable_status?(response.status_code) && attempt < MAX_RETRIES
               Log.warn { "LLM request failed with #{response.status_code}. Retrying in #{retry_delay} (attempt #{attempt + 1}/#{MAX_RETRIES})..." }
-              sleep(retry_delay)
-              retry_delay *= 2
+              retry_delay = sleep_with_backoff(retry_delay)
               next
             end
 
             Log.debug { "Response #{response.status_code}: #{response.body}" }
             return response
           rescue ex : IO::TimeoutError | Socket::Error
-            if attempt < MAX_RETRIES
-              Log.warn { "LLM request failed: #{ex.message}. Retrying in #{retry_delay} (attempt #{attempt + 1}/#{MAX_RETRIES})..." }
-              sleep(retry_delay)
-              retry_delay *= 2
-            else
-              raise ex
-            end
+            client.close
+            raise ex unless attempt < MAX_RETRIES
+
+            Log.warn { "LLM request failed: #{ex.message}. Retrying in #{retry_delay} (attempt #{attempt + 1}/#{MAX_RETRIES})..." }
+            retry_delay = sleep_with_backoff(retry_delay)
+            client = build_http_client(host, uri.port, tls)
           end
         end
 
-        last_response || raise "HTTP request failed without response"
+        raise "HTTP request failed: max retries exhausted"
+      ensure
+        client.try(&.close)
       end
 
-      private def do_http_post(host, port, tls, path, headers, body) : HTTP::Client::Response
+      private def build_http_client(host : String, port : Int32?, tls : Bool) : HTTP::Client
         client = HTTP::Client.new(host, port: port, tls: tls)
         client.connect_timeout = CONNECT_TIMEOUT
         client.read_timeout = READ_TIMEOUT
-        begin
-          client.post(path, headers: headers, body: body)
-        ensure
-          client.close
-        end
+        client
+      end
+
+      private def do_http_post(client : HTTP::Client, path : String, headers : HTTP::Headers, body : String) : HTTP::Client::Response
+        client.post(path, headers: headers, body: body)
+      end
+
+      private def initial_retry_delay : Time::Span
+        INITIAL_RETRY_DELAY
+      end
+
+      private def retryable_status?(status_code : Int32) : Bool
+        status_code == RATE_LIMIT_STATUS ||
+          (status_code >= SERVER_ERROR_MIN && status_code <= SERVER_ERROR_MAX)
+      end
+
+      private def sleep_with_backoff(delay : Time::Span) : Time::Span
+        sleep(delay)
+        delay * 2
       end
     end
   end

--- a/src/autobot/providers/http_provider.cr
+++ b/src/autobot/providers/http_provider.cr
@@ -20,6 +20,9 @@ module Autobot
       USER_AGENT            = "Autobot/#{VERSION}"
       ANTHROPIC_API_VERSION = "2023-06-01"
 
+      MAX_RETRIES          = 3
+      INITIAL_RETRY_DELAY = 2.seconds
+
       getter model : String
       getter extra_headers : Hash(String, String)
 
@@ -602,21 +605,50 @@ module Autobot
         host = uri.host
         raise "Invalid URL: missing host in '#{url}'" unless host
 
-        client = HTTP::Client.new(host, port: uri.port, tls: tls)
-        client.connect_timeout = CONNECT_TIMEOUT
-        client.read_timeout = READ_TIMEOUT
-
         path = uri.request_target
-        response = client.post(path, headers: headers, body: body)
+        last_response : HTTP::Client::Response? = nil
+        retry_delay = INITIAL_RETRY_DELAY
 
-        if response.success?
-          Log.debug { "Response #{response.status_code} (#{response.body.size} bytes)" }
-        else
-          Log.debug { "Response #{response.status_code}: #{response.body}" }
+        (0..MAX_RETRIES).each do |attempt|
+          client = HTTP::Client.new(host, port: uri.port, tls: tls)
+          client.connect_timeout = CONNECT_TIMEOUT
+          client.read_timeout = READ_TIMEOUT
+
+          begin
+            response = client.post(path, headers: headers, body: body)
+            last_response = response
+
+            if response.success?
+              Log.debug { "Response #{response.status_code} (#{response.body.size} bytes)" }
+              return response
+            end
+
+            # Retry on rate limits (429) or server errors (5xx)
+            should_retry = response.status_code == 429 || (response.status_code >= 500 && response.status_code <= 599)
+
+            if should_retry && attempt < MAX_RETRIES
+              Log.warn { "LLM request failed with #{response.status_code}. Retrying in #{retry_delay} (attempt #{attempt + 1}/#{MAX_RETRIES})..." }
+              sleep(retry_delay)
+              retry_delay *= 2
+              next
+            end
+
+            Log.debug { "Response #{response.status_code}: #{response.body}" }
+            return response
+          rescue ex : IO::TimeoutError | Socket::Error
+            if attempt < MAX_RETRIES
+              Log.warn { "LLM request failed: #{ex.message}. Retrying in #{retry_delay} (attempt #{attempt + 1}/#{MAX_RETRIES})..." }
+              sleep(retry_delay)
+              retry_delay *= 2
+            else
+              raise ex
+            end
+          ensure
+            client.close
+          end
         end
-        response
-      ensure
-        client.try(&.close)
+
+        last_response || raise "HTTP request failed without response"
       end
     end
   end


### PR DESCRIPTION
This PR introduces automatic retry logic to the HttpProvider. It now handles rate-limiting (429) and server-side errors (5xx) by waiting and retrying the request, significantly improving the bot's resilience during high-load periods or intermittent API issues.

Changes:

- Added retry loop in src/autobot/providers/http_provider.cr.
- Implemented configurable retry limits and backoff.
- Added unit tests in spec/autobot/providers/http_provider_spec.cr.