### PR TITLE
fix(cli): add workspace security warnings to doctor command

### DIFF
--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -759,4 +759,57 @@ describe Autobot::CLI::Doctor do
       Autobot::CLI::Doctor.pluralize("warning", 0).should eq("0 warnings")
     end
   end
+
+  describe ".check_workspace" do
+    it "passes for a safe subfolder workspace" do
+      tmp = TestHelper.tmp_dir
+      workspace = tmp / "workspace"
+      Dir.mkdir_p(workspace)
+      config = make_config("agents:\n  defaults:\n    workspace: #{workspace}")
+
+      with_doctor_io do |io|
+        errors, warnings = Autobot::CLI::Doctor.check_workspace(config, tmp / "config.yml", 0, 0)
+
+        errors.should eq(0)
+        warnings.should eq(0)
+        io.to_s.should contain("✓ Workspace exists")
+      end
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
+    it "warns when workspace is set to home directory" do
+      home = Path.home
+      config = make_config("agents:\n  defaults:\n    workspace: #{home}")
+
+      with_doctor_io do |io|
+        errors, warnings = Autobot::CLI::Doctor.check_workspace(config, Path["/tmp/config.yml"], 0, 0)
+
+        errors.should eq(0)
+        warnings.should eq(1)
+        io.to_s.should contain("! Workspace is set to home directory")
+        io.to_s.should contain("exposes secrets")
+      end
+    end
+
+    it "fails when .env is inside workspace" do
+      tmp = TestHelper.tmp_dir
+      workspace = tmp / "data"
+      Dir.mkdir_p(workspace)
+      env_file = workspace / ".env"
+      File.write(env_file, "KEY=VALUE")
+
+      config = make_config("agents:\n  defaults:\n    workspace: #{workspace}")
+
+      with_doctor_io do |io|
+        # config_file is in the same dir as .env for this test
+        errors, _warnings = Autobot::CLI::Doctor.check_workspace(config, workspace / "config.yml", 0, 0)
+
+        errors.should eq(1)
+        io.to_s.should contain("✗ .env file is inside workspace directory")
+      end
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+  end
 end

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -75,7 +75,7 @@ module Autobot
         errors = check_security_settings(config, errors)
 
         # Workspace
-        errors = check_workspace(config, config_file, errors)
+        errors, warnings = check_workspace(config, config_file, errors, warnings)
 
         # Channels
         warnings = check_channels(config, warnings)
@@ -224,7 +224,7 @@ module Autobot
         errors
       end
 
-      def self.check_workspace(config : Config::Config, config_file : Path, errors : Int32) : Int32
+      def self.check_workspace(config : Config::Config, config_file : Path, errors : Int32, warnings : Int32) : Tuple(Int32, Int32)
         workspace = config.workspace_path
 
         if Dir.exists?(workspace)
@@ -234,13 +234,14 @@ module Autobot
           hint("It will be created on first run")
         end
 
-        # Check if workspace is home directory (critical security risk)
+        # Check if workspace is home directory (security risk)
         home = Path.home.to_s
         workspace_real = File.realpath(workspace.to_s) rescue workspace.to_s
         if workspace_real == home
-          report(Status::Fail, "Workspace is set to home directory")
-          hint("This exposes ALL your personal files to the LLM. Use a dedicated subfolder instead.")
-          errors += 1
+          report(Status::Warn, "Workspace is set to home directory")
+          hint("This exposes secrets (like .env) and shell config (like .bashrc).")
+          hint("Best practice: use a dedicated subfolder (e.g., ./workspace) even for dedicated bot users.")
+          warnings += 1
         end
 
         # Check if .env is inside workspace (security risk)
@@ -255,7 +256,7 @@ module Autobot
           end
         end
 
-        errors
+        {errors, warnings}
       end
 
       def self.check_channels(config : Config::Config, warnings : Int32) : Int32

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -234,16 +234,24 @@ module Autobot
           hint("It will be created on first run")
         end
 
+        # Check if workspace is home directory (critical security risk)
+        home = Path.home.to_s
+        workspace_real = File.realpath(workspace.to_s) rescue workspace.to_s
+        if workspace_real == home
+          report(Status::Fail, "Workspace is set to home directory")
+          hint("This exposes ALL your personal files to the LLM. Use a dedicated subfolder instead.")
+          errors += 1
+        end
+
         # Check if .env is inside workspace (security risk)
         env_path = config_file.parent / ".env"
         if File.exists?(env_path.to_s)
           env_real = File.realpath(env_path.to_s)
-          workspace_real = File.realpath(workspace.to_s) rescue workspace.to_s
 
           if env_real.starts_with?(workspace_real)
             report(Status::Fail, ".env file is inside workspace directory")
             hint("Move .env outside workspace to prevent exposing secrets to the LLM")
-            return errors + 1
+            errors += 1
           end
         end
 


### PR DESCRIPTION
Updates the autobot doctor command to check for risky workspace locations. It specifically adds a warning if the workspace is initialized directly in the user's home directory, which can lead to unintentional file access or permission issues.

Changes:

- Added home directory check in src/autobot/cli/doctor.cr.
- Improved output formatting for security warnings.