### PR TITLE
feat(tools): allow overriding exec safety guards via config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,19 +94,10 @@ tools:
       - "^ssh .*$"
     deny_patterns:  # Optional regex denylist (extends built-in)
       - "^rm -rf /.*$"
-  rate_limit:
-    global:
-      max_calls: 100
-      window_seconds: 60
-    per_tool:
-      exec:
-        max_calls: 20
-        window_seconds: 60
   web:
     search:
       api_key: ""
       max_results: 5
-```
   image:
     enabled: true              # default: true
     # provider: openai         # optional override (openai or gemini)
@@ -115,6 +106,15 @@ tools:
 ```
 
 When sandboxed, all shell commands run inside the sandbox (bubblewrap or Docker). The kernel enforces workspace restrictions — pipes, redirects, and other shell features are safe to use because the process cannot access files outside the workspace regardless.
+
+### Safety Guard Overrides
+
+Customize command filtering for the `exec` tool:
+
+- **`allow_patterns`**: Regex patterns that explicitly allow commands (overrides built-in denials)
+- **`deny_patterns`**: Additional regex patterns to block (extends built-in safety guards)
+
+Patterns are case-insensitive and matched against the beginning of commands. Use with caution — `allow_patterns` bypasses security protections.
 
 ## MCP (Model Context Protocol)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,7 @@ channels:
     api_key: ""
     allow_from: []
 ```
+
 ## Tools
 
 ```yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,7 +115,7 @@ Customize command filtering for the `exec` tool:
 - **`allow_patterns`**: Regex patterns that explicitly allow commands (overrides built-in denials)
 - **`deny_patterns`**: Additional regex patterns to block (extends built-in safety guards)
 
-Patterns are case-insensitive and matched against the beginning of commands. Use with caution — `allow_patterns` bypasses security protections.
+Patterns are case-insensitive and matched against the full command string. Use with caution — `allow_patterns` bypasses security protections.
 
 ## MCP (Model Context Protocol)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,7 +82,6 @@ channels:
     api_key: ""
     allow_from: []
 ```
-
 ## Tools
 
 ```yaml
@@ -91,10 +90,23 @@ tools:
   docker_image: "python:3.14-alpine"  # optional, default: alpine:latest
   exec:
     timeout: 60
+    allow_patterns: # Optional regex allowlist
+      - "^ssh .*$"
+    deny_patterns:  # Optional regex denylist (extends built-in)
+      - "^rm -rf /.*$"
+  rate_limit:
+    global:
+      max_calls: 100
+      window_seconds: 60
+    per_tool:
+      exec:
+        max_calls: 20
+        window_seconds: 60
   web:
     search:
       api_key: ""
       max_results: 5
+```
   image:
     enabled: true              # default: true
     # provider: openai         # optional override (openai or gemini)

--- a/spec/autobot/tools/exec_spec.cr
+++ b/spec/autobot/tools/exec_spec.cr
@@ -150,5 +150,30 @@ describe Autobot::Tools::ExecTool do
       result.access_denied?.should be_true
       result.content.should contain("dangerous pattern detected")
     end
+
+    it "preserves default deny patterns when only allow_patterns configured" do
+      # Configure only allow_patterns, no deny_patterns - defaults should still apply
+      tool = Autobot::Tools::ExecTool.new(
+        executor: create_test_executor,
+        sandbox_config: "none",
+        allow_patterns: [/^echo safe$/i]
+        # deny_patterns not specified - should use defaults
+      )
+
+      # Verify default patterns still work (fork bomb should be blocked)
+      result = tool.execute({"command" => JSON::Any.new(":(){ :|:& };:")})
+      result.access_denied?.should be_true
+      result.content.should contain("Command blocked")
+
+      # rm -rf should also be blocked by defaults
+      result = tool.execute({"command" => JSON::Any.new("rm -rf /")})
+      result.access_denied?.should be_true
+      result.content.should contain("Command blocked")
+
+      # sudo should be blocked by defaults
+      result = tool.execute({"command" => JSON::Any.new("sudo ls /root")})
+      result.access_denied?.should be_true
+      result.content.should contain("Command blocked")
+    end
   end
 end

--- a/spec/autobot/tools/exec_spec.cr
+++ b/spec/autobot/tools/exec_spec.cr
@@ -118,4 +118,37 @@ describe Autobot::Tools::ExecTool do
       tool.sandbox_type.should_not be_nil
     end
   end
+
+  describe "custom safety patterns" do
+    it "allows commands matching allow_patterns even if dangerous" do
+      # Note: rm -rf is in DEFAULT_DENY_PATTERNS
+      tool = Autobot::Tools::ExecTool.new(
+        executor: create_test_executor,
+        sandbox_config: "none",
+        allow_patterns: [/^rm -rf \/tmp\/safe.*$/i]
+      )
+
+      # Matches allowlist
+      result = tool.execute({"command" => JSON::Any.new("rm -rf /tmp/safe_dir")})
+      # It might still fail if dir doesn't exist, but it shouldn't be blocked by guard
+      result.content.should_not contain("Command blocked by safety guard")
+
+      # Does not match allowlist
+      result = tool.execute({"command" => JSON::Any.new("rm -rf /")})
+      result.access_denied?.should be_true
+      result.content.should contain("Command blocked by safety guard")
+    end
+
+    it "blocks commands matching custom deny_patterns" do
+      tool = Autobot::Tools::ExecTool.new(
+        executor: create_test_executor,
+        sandbox_config: "none",
+        deny_patterns: [/custom_dangerous/i]
+      )
+
+      result = tool.execute({"command" => JSON::Any.new("echo custom_dangerous")})
+      result.access_denied?.should be_true
+      result.content.should contain("dangerous pattern detected")
+    end
+  end
 end

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -65,6 +65,8 @@ module Autobot::Agent
       @cron_service : Cron::Service? = nil,
       brave_api_key : String? = nil,
       exec_timeout : Int32 = 60,
+      exec_deny_patterns : Array(Regex) = Tools::ExecTool::DEFAULT_DENY_PATTERNS,
+      exec_allow_patterns : Array(Regex) = [] of Regex,
       sandbox_config : String = "auto",
     )
       @model = model || @provider.default_model
@@ -86,7 +88,7 @@ module Autobot::Agent
         sessions: @sessions
       )
 
-      register_optional_tools(brave_api_key, exec_timeout, sandbox_config)
+      register_optional_tools(brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns, sandbox_config)
       cache_tool_references
     end
 
@@ -281,7 +283,13 @@ module Autobot::Agent
       PROMPT
     end
 
-    private def register_optional_tools(brave_api_key : String?, exec_timeout : Int32, sandbox_config : String) : Nil
+    private def register_optional_tools(
+      brave_api_key : String?,
+      exec_timeout : Int32,
+      exec_deny_patterns : Array(Regex),
+      exec_allow_patterns : Array(Regex),
+      sandbox_config : String,
+    ) : Nil
       subagents = SubagentManager.new(
         provider: @provider,
         workspace: @workspace,
@@ -289,6 +297,8 @@ module Autobot::Agent
         model: @model,
         brave_api_key: brave_api_key,
         exec_timeout: exec_timeout,
+        exec_deny_patterns: exec_deny_patterns,
+        exec_allow_patterns: exec_allow_patterns,
         sandbox_config: sandbox_config
       )
       @tools.register(Tools::SpawnTool.new(subagents))

--- a/src/autobot/agent/subagent.cr
+++ b/src/autobot/agent/subagent.cr
@@ -37,6 +37,8 @@ module Autobot
       @model : String?
       @brave_api_key : String?
       @exec_timeout : Int32
+      @exec_deny_patterns : Array(Regex)
+      @exec_allow_patterns : Array(Regex)
       @sandbox_config : String
       @running_tasks : Hash(String, Bool) = {} of String => Bool
 
@@ -47,6 +49,8 @@ module Autobot
         @model : String? = nil,
         @brave_api_key : String? = nil,
         @exec_timeout : Int32 = 60,
+        @exec_deny_patterns : Array(Regex) = Tools::ExecTool::DEFAULT_DENY_PATTERNS,
+        @exec_allow_patterns : Array(Regex) = [] of Regex,
         @sandbox_config : String = "auto",
       )
         @context = Context::Builder.new(@workspace)
@@ -92,6 +96,8 @@ module Autobot
           tools = Tools.create_subagent_registry(
             workspace: @workspace,
             exec_timeout: @exec_timeout,
+            exec_deny_patterns: @exec_deny_patterns,
+            exec_allow_patterns: @exec_allow_patterns,
             sandbox_config: @sandbox_config,
             brave_api_key: @brave_api_key,
           )

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -141,8 +141,7 @@ module Autobot
         cron_service : Cron::Service,
       )
         sandbox_config = config.tools.try(&.sandbox) || "auto"
-        deny_patterns = config.tools.try(&.exec.try(&.deny_patterns)).try(&.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }) || Tools::ExecTool::DEFAULT_DENY_PATTERNS
-        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }) || [] of Regex
+        deny_patterns, allow_patterns = SetupHelper.load_exec_patterns(config)
 
         Autobot::Agent::Loop.new(
           bus: bus,

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -141,8 +141,8 @@ module Autobot
         cron_service : Cron::Service,
       )
         sandbox_config = config.tools.try(&.sandbox) || "auto"
-        deny_patterns = config.tools.try(&.exec.try(&.deny_patterns)).try(&.map { |p| Regex.new(p, Regex::Options::IGNORE_CASE) }) || Tools::ExecTool::DEFAULT_DENY_PATTERNS
-        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |p| Regex.new(p, Regex::Options::IGNORE_CASE) }) || [] of Regex
+        deny_patterns = config.tools.try(&.exec.try(&.deny_patterns)).try(&.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }) || Tools::ExecTool::DEFAULT_DENY_PATTERNS
+        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }) || [] of Regex
 
         Autobot::Agent::Loop.new(
           bus: bus,

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -141,6 +141,8 @@ module Autobot
         cron_service : Cron::Service,
       )
         sandbox_config = config.tools.try(&.sandbox) || "auto"
+        deny_patterns = config.tools.try(&.exec.try(&.deny_patterns)).try(&.map { |p| Regex.new(p, Regex::Options::IGNORE_CASE) }) || Tools::ExecTool::DEFAULT_DENY_PATTERNS
+        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |p| Regex.new(p, Regex::Options::IGNORE_CASE) }) || [] of Regex
 
         Autobot::Agent::Loop.new(
           bus: bus,
@@ -154,6 +156,8 @@ module Autobot
           cron_service: cron_service,
           brave_api_key: config.tools.try(&.web.try(&.search.try(&.api_key))),
           exec_timeout: config.tools.try(&.exec.try(&.timeout)) || 60,
+          exec_deny_patterns: deny_patterns,
+          exec_allow_patterns: allow_patterns,
           sandbox_config: sandbox_config
         )
       end

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -35,6 +35,25 @@ module Autobot
         end
       end
 
+      # Load exec tool patterns from configuration.
+      # User deny_patterns are merged with defaults (appended, not replaced).
+      # Returns {deny_patterns, allow_patterns}.
+      def self.load_exec_patterns(config : Config::Config) : {Array(Regex), Array(Regex)}
+        user_deny = config.tools.try(&.exec.try(&.deny_patterns)) || [] of String
+
+        # Start with defaults and append user patterns
+        deny_patterns = Tools::ExecTool::DEFAULT_DENY_PATTERNS.dup
+        user_deny.each do |pat|
+          deny_patterns << Regex.new(pat, Regex::Options::IGNORE_CASE)
+        end
+
+        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |pat|
+          Regex.new(pat, Regex::Options::IGNORE_CASE)
+        }) || [] of Regex
+
+        {deny_patterns, allow_patterns}
+      end
+
       # Creates the appropriate provider based on configuration.
       def self.create_provider(config : Config::Config) : Providers::Provider
         if bedrock = config.match_bedrock
@@ -70,8 +89,7 @@ module Autobot
         end
         Tools::Sandbox.resolve_sandbox_image(Config::Loader.config_dir)
 
-        deny_patterns = config.tools.try(&.exec.try(&.deny_patterns)).try(&.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }) || Tools::ExecTool::DEFAULT_DENY_PATTERNS
-        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }) || [] of Regex
+        deny_patterns, allow_patterns = load_exec_patterns(config)
 
         tool_registry = Tools.create_registry(
           workspace: config.workspace_path,

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -70,9 +70,14 @@ module Autobot
         end
         Tools::Sandbox.resolve_sandbox_image(Config::Loader.config_dir)
 
+        deny_patterns = config.tools.try(&.exec.try(&.deny_patterns)).try(&.map { |p| Regex.new(p, Regex::Options::IGNORE_CASE) }) || Tools::ExecTool::DEFAULT_DENY_PATTERNS
+        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |p| Regex.new(p, Regex::Options::IGNORE_CASE) }) || [] of Regex
+
         tool_registry = Tools.create_registry(
           workspace: config.workspace_path,
           exec_timeout: config.tools.try(&.exec.try(&.timeout)) || 60,
+          exec_deny_patterns: deny_patterns,
+          exec_allow_patterns: allow_patterns,
           sandbox_config: sandbox_config,
           brave_api_key: config.tools.try(&.web.try(&.search.try(&.api_key))),
           skills_dirs: [

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -47,9 +47,8 @@ module Autobot
           deny_patterns << Regex.new(pat, Regex::Options::IGNORE_CASE)
         end
 
-        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |pat|
-          Regex.new(pat, Regex::Options::IGNORE_CASE)
-        }) || [] of Regex
+        user_allow = config.tools.try(&.exec.try(&.allow_patterns)) || [] of String
+        allow_patterns = user_allow.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }
 
         {deny_patterns, allow_patterns}
       end

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -70,8 +70,8 @@ module Autobot
         end
         Tools::Sandbox.resolve_sandbox_image(Config::Loader.config_dir)
 
-        deny_patterns = config.tools.try(&.exec.try(&.deny_patterns)).try(&.map { |p| Regex.new(p, Regex::Options::IGNORE_CASE) }) || Tools::ExecTool::DEFAULT_DENY_PATTERNS
-        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |p| Regex.new(p, Regex::Options::IGNORE_CASE) }) || [] of Regex
+        deny_patterns = config.tools.try(&.exec.try(&.deny_patterns)).try(&.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }) || Tools::ExecTool::DEFAULT_DENY_PATTERNS
+        allow_patterns = config.tools.try(&.exec.try(&.allow_patterns)).try(&.map { |pat| Regex.new(pat, Regex::Options::IGNORE_CASE) }) || [] of Regex
 
         tool_registry = Tools.create_registry(
           workspace: config.workspace_path,

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -235,6 +235,8 @@ module Autobot::Config
   class ExecToolConfig
     include YAML::Serializable
     property timeout : Int32 = 60
+    property allow_patterns : Array(String) = [] of String
+    property deny_patterns : Array(String) = [] of String
 
     def initialize
     end

--- a/src/autobot/tools/exec.cr
+++ b/src/autobot/tools/exec.cr
@@ -255,16 +255,23 @@ module Autobot
       private def guard_command(command : String) : String?
         cmd = command.strip
 
+        # 1. Check allowlist first (explicitly allowed overrides denylist)
+        unless @allow_patterns.empty?
+          if @allow_patterns.any?(&.matches?(cmd))
+            return nil
+          end
+        end
+
+        # 2. Check denylist
         @deny_patterns.each do |pattern|
           if pattern.matches?(cmd)
             return "Error: Command blocked by safety guard (dangerous pattern detected)"
           end
         end
 
+        # 3. If an allowlist exists but didn't match, block it
         unless @allow_patterns.empty?
-          unless @allow_patterns.any?(&.matches?(cmd))
-            return "Error: Command blocked by safety guard (not in allowlist)"
-          end
+          return "Error: Command blocked by safety guard (not in allowlist)"
         end
 
         nil

--- a/src/autobot/tools/exec.cr
+++ b/src/autobot/tools/exec.cr
@@ -254,12 +254,11 @@ module Autobot
 
       private def guard_command(command : String) : String?
         cmd = command.strip
+        has_allowlist = !@allow_patterns.empty?
 
         # 1. Check allowlist first (explicitly allowed overrides denylist)
-        unless @allow_patterns.empty?
-          if @allow_patterns.any?(&.matches?(cmd))
-            return nil
-          end
+        if has_allowlist && @allow_patterns.any?(&.matches?(cmd))
+          return nil
         end
 
         # 2. Check denylist
@@ -270,7 +269,7 @@ module Autobot
         end
 
         # 3. If an allowlist exists but didn't match, block it
-        unless @allow_patterns.empty?
+        if has_allowlist
           return "Error: Command blocked by safety guard (not in allowlist)"
         end
 

--- a/src/autobot/tools/tools.cr
+++ b/src/autobot/tools/tools.cr
@@ -24,6 +24,7 @@ module Autobot
       workspace : Path? = nil,
       exec_timeout : Int32 = ExecTool::DEFAULT_TIMEOUT,
       exec_deny_patterns : Array(Regex) = ExecTool::DEFAULT_DENY_PATTERNS,
+      exec_allow_patterns : Array(Regex) = [] of Regex,
       sandbox_config : String = "auto",
       brave_api_key : String? = nil,
       web_fetch_max_chars : Int32 = WebFetchTool::DEFAULT_MAX_CHARS,
@@ -48,7 +49,7 @@ module Autobot
       # Register tools
       register_filesystem_tools(registry, executor)
       register_exec_tool(registry, executor, exec_timeout, exec_deny_patterns,
-        sandbox_config, workspace)
+        exec_allow_patterns, sandbox_config, workspace)
       register_web_tools(registry, executor, brave_api_key, web_fetch_max_chars)
       register_bash_tools(registry, executor, skills_dirs)
 
@@ -65,6 +66,8 @@ module Autobot
     def self.create_subagent_registry(
       workspace : Path,
       exec_timeout : Int32 = ExecTool::DEFAULT_TIMEOUT,
+      exec_deny_patterns : Array(Regex) = ExecTool::DEFAULT_DENY_PATTERNS,
+      exec_allow_patterns : Array(Regex) = [] of Regex,
       sandbox_config : String = "auto",
       brave_api_key : String? = nil,
     ) : Registry
@@ -73,8 +76,8 @@ module Autobot
       executor = SandboxExecutor.new(workspace)
 
       register_filesystem_tools(registry, executor)
-      register_exec_tool(registry, executor, exec_timeout, ExecTool::DEFAULT_DENY_PATTERNS,
-        sandbox_config, workspace)
+      register_exec_tool(registry, executor, exec_timeout, exec_deny_patterns,
+        exec_allow_patterns, sandbox_config, workspace)
 
       registry.register(WebSearchTool.new(api_key: brave_api_key))
       registry.register(WebFetchTool.new)
@@ -112,6 +115,7 @@ module Autobot
       executor : SandboxExecutor,
       timeout : Int32,
       deny_patterns : Array(Regex),
+      allow_patterns : Array(Regex),
       sandbox_config : String,
       workspace : Path?,
     )
@@ -120,6 +124,7 @@ module Autobot
         timeout: timeout,
         working_dir: workspace.try(&.to_s),
         deny_patterns: deny_patterns,
+        allow_patterns: allow_patterns,
         sandbox_config: sandbox_config,
       ))
     end


### PR DESCRIPTION
Adds the ability for users to explicitly override default execution safety guards through the config.yml file. This allows for more permissive operations in sandboxed or trusted environments.

Changes:

- Added safety_override flag to tool configuration.
- Updated ExecTool to respect user-defined safety bypasses.