### PR TITLE
feat(tools): allow overriding tool rate limits via config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,6 @@ tools:
     search:
       api_key: ""
       max_results: 5
-```
   image:
     enabled: true              # default: true
     # provider: openai         # optional override (openai or gemini)
@@ -111,6 +110,19 @@ tools:
 ```
 
 When sandboxed, all shell commands run inside the sandbox (bubblewrap or Docker). The kernel enforces workspace restrictions — pipes, redirects, and other shell features are safe to use because the process cannot access files outside the workspace regardless.
+
+### Rate Limiting
+
+Configure rate limits to prevent abuse and manage API costs:
+
+- **`global`**: Applies across all tools combined
+- **`per_tool`**: Tool-specific limits (e.g., `exec`, `web_search`)
+
+Each limit specifies:
+- **`max_calls`**: Maximum calls allowed in the window
+- **`window_seconds`**: Time window for counting calls
+
+When a limit is exceeded, the tool returns an error message that the LLM can see and respond to (e.g., "Rate limit exceeded for exec: max 20 calls per 60s").
 
 ## MCP (Model Context Protocol)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,7 @@ channels:
     api_key: ""
     allow_from: []
 ```
+
 ## Tools
 
 ```yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,7 +82,6 @@ channels:
     api_key: ""
     allow_from: []
 ```
-
 ## Tools
 
 ```yaml
@@ -91,10 +90,19 @@ tools:
   docker_image: "python:3.14-alpine"  # optional, default: alpine:latest
   exec:
     timeout: 60
+  rate_limit:
+    global:
+      max_calls: 100
+      window_seconds: 60
+    per_tool:
+      exec:
+        max_calls: 20
+        window_seconds: 60
   web:
     search:
       api_key: ""
       max_results: 5
+```
   image:
     enabled: true              # default: true
     # provider: openai         # optional override (openai or gemini)

--- a/spec/security_spec.cr
+++ b/spec/security_spec.cr
@@ -183,6 +183,30 @@ describe "Security Tests" do
         fail "Expected rate limit error"
       end
     end
+
+    it "loads limits from configuration" do
+      yaml = <<-YAML
+      tools:
+        rate_limit:
+          global:
+            max_calls: 50
+            window_seconds: 30
+          per_tool:
+            exec:
+              max_calls: 5
+              window_seconds: 60
+      YAML
+
+      config = Autobot::Config::Config.from_yaml(yaml)
+      limiter = Autobot::Tools::RateLimiter.from_config(config.tools.try(&.rate_limit))
+
+      # Verify per-tool limit
+      5.times do
+        limiter.check_limit("exec", "session").should be_nil
+        limiter.record_call("exec", "session")
+      end
+      limiter.check_limit("exec", "session").not_nil!.should contain("max 5 calls")
+    end
   end
 
   describe "Log sanitization" do

--- a/spec/security_spec.cr
+++ b/spec/security_spec.cr
@@ -205,7 +205,11 @@ describe "Security Tests" do
         limiter.check_limit("exec", "session").should be_nil
         limiter.record_call("exec", "session")
       end
-      limiter.check_limit("exec", "session").not_nil!.should contain("max 5 calls")
+      if error = limiter.check_limit("exec", "session")
+        error.should contain("max 5 calls")
+      else
+        fail("Expected rate limit error")
+      end
     end
   end
 

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -66,6 +66,7 @@ module Autobot::Agent
       brave_api_key : String? = nil,
       exec_timeout : Int32 = 60,
       sandbox_config : String = "auto",
+      rate_limiter : Tools::RateLimiter? = nil,
     )
       @model = model || @provider.default_model
       sandboxed = sandbox_config.downcase != "none"
@@ -86,7 +87,7 @@ module Autobot::Agent
         sessions: @sessions
       )
 
-      register_optional_tools(brave_api_key, exec_timeout, sandbox_config)
+      register_optional_tools(brave_api_key, exec_timeout, sandbox_config, rate_limiter)
       cache_tool_references
     end
 
@@ -281,7 +282,12 @@ module Autobot::Agent
       PROMPT
     end
 
-    private def register_optional_tools(brave_api_key : String?, exec_timeout : Int32, sandbox_config : String) : Nil
+    private def register_optional_tools(
+      brave_api_key : String?,
+      exec_timeout : Int32,
+      sandbox_config : String,
+      rate_limiter : Tools::RateLimiter?,
+    ) : Nil
       subagents = SubagentManager.new(
         provider: @provider,
         workspace: @workspace,
@@ -289,7 +295,8 @@ module Autobot::Agent
         model: @model,
         brave_api_key: brave_api_key,
         exec_timeout: exec_timeout,
-        sandbox_config: sandbox_config
+        sandbox_config: sandbox_config,
+        rate_limiter: rate_limiter
       )
       @tools.register(Tools::SpawnTool.new(subagents))
 

--- a/src/autobot/agent/subagent.cr
+++ b/src/autobot/agent/subagent.cr
@@ -38,6 +38,7 @@ module Autobot
       @brave_api_key : String?
       @exec_timeout : Int32
       @sandbox_config : String
+      @rate_limiter : Tools::RateLimiter?
       @running_tasks : Hash(String, Bool) = {} of String => Bool
 
       def initialize(
@@ -48,6 +49,7 @@ module Autobot
         @brave_api_key : String? = nil,
         @exec_timeout : Int32 = 60,
         @sandbox_config : String = "auto",
+        @rate_limiter : Tools::RateLimiter? = nil,
       )
         @context = Context::Builder.new(@workspace)
       end
@@ -94,6 +96,7 @@ module Autobot
             exec_timeout: @exec_timeout,
             sandbox_config: @sandbox_config,
             brave_api_key: @brave_api_key,
+            rate_limiter: @rate_limiter,
           )
 
           executor = ToolExecutor.new(

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -19,7 +19,7 @@ module Autobot
         bus = Bus::MessageBus.new
         session_manager = Session::Manager.new(config.workspace_path)
 
-        tool_registry, mcp_clients = setup_tools(config)
+        tool_registry, mcp_clients, rate_limiter = setup_tools(config)
         provider = create_provider(config)
 
         elapsed_ms = started_at.elapsed.total_milliseconds.to_i
@@ -29,7 +29,7 @@ module Autobot
         plugin_registry = SetupHelper.load_plugins(config, tool_registry)
         cron_service = setup_cron(config, bus)
         channel_manager = setup_channels(config, bus, session_manager, cron_service)
-        agent_loop = create_agent_loop(config, bus, provider, tool_registry, session_manager, cron_service)
+        agent_loop = create_agent_loop(config, bus, provider, tool_registry, session_manager, cron_service, rate_limiter)
 
         # Handle shutdown signals
         shutdown = -> do
@@ -54,12 +54,12 @@ module Autobot
       end
 
       private def self.setup_tools(config : Config::Config)
-        tool_registry, mcp_clients = SetupHelper.setup_tools(config)
+        tool_registry, mcp_clients, rate_limiter = SetupHelper.setup_tools(config)
 
         sandbox_config = config.tools.try(&.sandbox) || "auto"
         log_sandbox_info(sandbox_config)
 
-        {tool_registry, mcp_clients}
+        {tool_registry, mcp_clients, rate_limiter}
       end
 
       private def self.setup_cron(config : Config::Config, bus : Bus::MessageBus) : Cron::Service
@@ -139,9 +139,9 @@ module Autobot
         tool_registry : Tools::Registry,
         session_manager : Session::Manager,
         cron_service : Cron::Service,
+        rate_limiter : Tools::RateLimiter? = nil,
       )
         sandbox_config = config.tools.try(&.sandbox) || "auto"
-        rate_limiter = Tools::RateLimiter.from_config(config.tools.try(&.rate_limit))
 
         Autobot::Agent::Loop.new(
           bus: bus,

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -141,6 +141,7 @@ module Autobot
         cron_service : Cron::Service,
       )
         sandbox_config = config.tools.try(&.sandbox) || "auto"
+        rate_limiter = Tools::RateLimiter.from_config(config.tools.try(&.rate_limit))
 
         Autobot::Agent::Loop.new(
           bus: bus,
@@ -154,7 +155,8 @@ module Autobot
           cron_service: cron_service,
           brave_api_key: config.tools.try(&.web.try(&.search.try(&.api_key))),
           exec_timeout: config.tools.try(&.exec.try(&.timeout)) || 60,
-          sandbox_config: sandbox_config
+          sandbox_config: sandbox_config,
+          rate_limiter: rate_limiter
         )
       end
 

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -60,8 +60,8 @@ module Autobot
       end
 
       # Sets up tool registry with built-in tools and MCP servers.
-      # Returns {tool_registry, mcp_clients}. Plugins are loaded separately
-      # via `load_plugins` to avoid blocking startup.
+      # Returns {tool_registry, mcp_clients, rate_limiter}. Plugins are loaded
+      # separately via `load_plugins` to avoid blocking startup.
       def self.setup_tools(config : Config::Config)
         sandbox_config = config.tools.try(&.sandbox) || "auto"
 
@@ -89,7 +89,7 @@ module Autobot
         # MCP servers (started in background, tools register as they connect)
         mcp_clients = Mcp.setup(config, tool_registry)
 
-        {tool_registry, mcp_clients}
+        {tool_registry, mcp_clients, rate_limiter}
       end
 
       # Load and start plugins. Call after gateway is ready to avoid

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -70,6 +70,8 @@ module Autobot
         end
         Tools::Sandbox.resolve_sandbox_image(Config::Loader.config_dir)
 
+        rate_limiter = Tools::RateLimiter.from_config(config.tools.try(&.rate_limit))
+
         tool_registry = Tools.create_registry(
           workspace: config.workspace_path,
           exec_timeout: config.tools.try(&.exec.try(&.timeout)) || 60,
@@ -78,7 +80,8 @@ module Autobot
           skills_dirs: [
             (config.workspace_path / "skills").to_s,
             (Config::Loader.skills_dir).to_s,
-          ]
+          ],
+          rate_limiter: rate_limiter
         )
 
         register_image_tool(config, tool_registry)

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -235,6 +235,26 @@ module Autobot::Config
   class ExecToolConfig
     include YAML::Serializable
     property timeout : Int32 = 60
+    property allow_patterns : Array(String) = [] of String
+    property deny_patterns : Array(String) = [] of String
+
+    def initialize
+    end
+  end
+
+  class ToolRateLimitConfig
+    include YAML::Serializable
+    property max_calls : Int32
+    property window_seconds : Int32 = 60
+
+    def initialize(@max_calls, @window_seconds = 60)
+    end
+  end
+
+  class RateLimitConfig
+    include YAML::Serializable
+    property global : ToolRateLimitConfig?
+    property per_tool : Hash(String, ToolRateLimitConfig)?
 
     def initialize
     end
@@ -258,6 +278,7 @@ module Autobot::Config
     property image : ImageConfig?
     property sandbox : String = "auto" # "auto", "bubblewrap", "docker", "none"
     property docker_image : String? = nil
+    property rate_limit : RateLimitConfig?
 
     def initialize
     end

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -235,8 +235,6 @@ module Autobot::Config
   class ExecToolConfig
     include YAML::Serializable
     property timeout : Int32 = 60
-    property allow_patterns : Array(String) = [] of String
-    property deny_patterns : Array(String) = [] of String
 
     def initialize
     end

--- a/src/autobot/providers/http_provider.cr
+++ b/src/autobot/providers/http_provider.cr
@@ -622,7 +622,7 @@ module Autobot
             end
 
             if retryable_status?(response.status_code) && attempt < MAX_RETRIES
-              Log.warn { "LLM request failed with #{response.status_code}. Retrying in #{retry_delay} (attempt #{attempt + 1}/#{MAX_RETRIES})..." }
+              log_retry(attempt, "HTTP #{response.status_code}", retry_delay)
               retry_delay = sleep_with_backoff(retry_delay)
               next
             end
@@ -633,7 +633,7 @@ module Autobot
             client.close
             raise ex unless attempt < MAX_RETRIES
 
-            Log.warn { "LLM request failed: #{ex.message}. Retrying in #{retry_delay} (attempt #{attempt + 1}/#{MAX_RETRIES})..." }
+            log_retry(attempt, ex.message || "unknown error", retry_delay)
             retry_delay = sleep_with_backoff(retry_delay)
             client = build_http_client(host, uri.port, tls)
           end
@@ -662,6 +662,10 @@ module Autobot
       private def retryable_status?(status_code : Int32) : Bool
         status_code == RATE_LIMIT_STATUS ||
           (status_code >= SERVER_ERROR_MIN && status_code <= SERVER_ERROR_MAX)
+      end
+
+      private def log_retry(attempt : Int32, reason : String, delay : Time::Span) : Nil
+        Log.warn { "LLM request failed: #{reason}. Retrying in #{delay} (attempt #{attempt + 1}/#{MAX_RETRIES})..." }
       end
 
       private def sleep_with_backoff(delay : Time::Span) : Time::Span

--- a/src/autobot/tools/rate_limiter.cr
+++ b/src/autobot/tools/rate_limiter.cr
@@ -35,14 +35,18 @@ module Autobot
         end
       end
 
+      DEFAULT_SESSION_LIMIT = Limit.new(max_calls: 30, window_seconds: 60)
+
       @trackers : Hash(String, CallTracker)
       @mutex : Mutex
       @per_tool_limits : Hash(String, Limit)
       @global_limit : Limit?
+      @session_limit : Limit
 
       def initialize(
         @per_tool_limits = {} of String => Limit,
         @global_limit : Limit? = nil,
+        @session_limit : Limit = DEFAULT_SESSION_LIMIT,
       )
         @trackers = {} of String => CallTracker
         @mutex = Mutex.new
@@ -89,8 +93,7 @@ module Autobot
           end
 
           # Check per-session limit for this tool
-          session_limit = Limit.new(max_calls: 30, window_seconds: 60)
-          if error = check_specific_limit("session:#{session_key}:#{tool_name}", session_limit, now)
+          if error = check_specific_limit("session:#{session_key}:#{tool_name}", @session_limit, now)
             Log.warn { "Session rate limit exceeded for #{session_key}" }
             return error
           end
@@ -135,9 +138,14 @@ module Autobot
       private def check_specific_limit(key : String, limit : Limit, now : Time) : String?
         tracker = @trackers[key] ||= CallTracker.new
 
-        # Remove expired calls
+        # Remove expired calls and evict empty trackers
         cutoff = now - limit.window_seconds.seconds
         tracker.cleanup(cutoff)
+
+        if tracker.count == 0
+          @trackers.delete(key)
+          return nil
+        end
 
         # Check if limit exceeded
         if tracker.count >= limit.max_calls

--- a/src/autobot/tools/rate_limiter.cr
+++ b/src/autobot/tools/rate_limiter.cr
@@ -47,13 +47,31 @@ module Autobot
         @trackers = {} of String => CallTracker
         @mutex = Mutex.new
 
-        # Default limits for high-risk tools
+        # Default limits for high-risk tools if not already provided
         @per_tool_limits["exec"] ||= Limit.new(max_calls: 10, window_seconds: 60)
         @per_tool_limits["web_fetch"] ||= Limit.new(max_calls: 20, window_seconds: 60)
         @per_tool_limits["web_search"] ||= Limit.new(max_calls: 10, window_seconds: 60)
 
-        # Default global limit: 100 calls per minute
+        # Default global limit: 100 calls per minute if not provided
         @global_limit ||= Limit.new(max_calls: 100, window_seconds: 60)
+      end
+
+      # Factory method to create from config
+      def self.from_config(config : Config::RateLimitConfig?) : RateLimiter
+        per_tool = {} of String => Limit
+        global : Limit? = nil
+
+        if config
+          config.per_tool.try(&.each do |name, c|
+            per_tool[name] = Limit.new(max_calls: c.max_calls, window_seconds: c.window_seconds)
+          end)
+
+          config.global.try do |c|
+            global = Limit.new(max_calls: c.max_calls, window_seconds: c.window_seconds)
+          end
+        end
+
+        new(per_tool_limits: per_tool, global_limit: global)
       end
 
       # Check if a tool call is allowed

--- a/src/autobot/tools/rate_limiter.cr
+++ b/src/autobot/tools/rate_limiter.cr
@@ -62,12 +62,12 @@ module Autobot
         global : Limit? = nil
 
         if config
-          config.per_tool.try(&.each do |name, c|
-            per_tool[name] = Limit.new(max_calls: c.max_calls, window_seconds: c.window_seconds)
+          config.per_tool.try(&.each do |name, cfg|
+            per_tool[name] = Limit.new(max_calls: cfg.max_calls, window_seconds: cfg.window_seconds)
           end)
 
-          config.global.try do |c|
-            global = Limit.new(max_calls: c.max_calls, window_seconds: c.window_seconds)
+          config.global.try do |cfg|
+            global = Limit.new(max_calls: cfg.max_calls, window_seconds: cfg.window_seconds)
           end
         end
 

--- a/src/autobot/tools/registry.cr
+++ b/src/autobot/tools/registry.cr
@@ -12,9 +12,9 @@ module Autobot::Tools
     @session_key : String
     @sandbox_executor : SandboxExecutor?
 
-    def initialize(@session_key : String = "default")
+    def initialize(@session_key : String = "default", rate_limiter : RateLimiter? = nil)
       @tools = {} of String => Tool
-      @rate_limiter = RateLimiter.new
+      @rate_limiter = rate_limiter || RateLimiter.new
       @sandbox_executor = nil
     end
 

--- a/src/autobot/tools/tools.cr
+++ b/src/autobot/tools/tools.cr
@@ -28,8 +28,9 @@ module Autobot
       brave_api_key : String? = nil,
       web_fetch_max_chars : Int32 = WebFetchTool::DEFAULT_MAX_CHARS,
       skills_dirs : Array(String) = [] of String,
+      rate_limiter : RateLimiter? = nil,
     ) : Registry
-      registry = Registry.new
+      registry = Registry.new(rate_limiter: rate_limiter)
 
       # Determine sandbox configuration
       sandboxed = sandbox_config.downcase != "none"
@@ -67,8 +68,9 @@ module Autobot
       exec_timeout : Int32 = ExecTool::DEFAULT_TIMEOUT,
       sandbox_config : String = "auto",
       brave_api_key : String? = nil,
+      rate_limiter : RateLimiter? = nil,
     ) : Registry
-      registry = Registry.new
+      registry = Registry.new(rate_limiter: rate_limiter)
 
       executor = SandboxExecutor.new(workspace)
 


### PR DESCRIPTION
This PR allows users to customize the rate limits for specific tools via the global configuration. It's particularly useful for high-performance setups where default limits are too restrictive.

Changes:

- Updated the RateLimiter to pull overrides from the configuration schema.
- Added tests for dynamic rate limit adjustment.