### PR TITLE
fix(cli): default Gemini config to gemini-2.5-flash

### DIFF
--- a/spec/autobot/providers/registry_spec.cr
+++ b/spec/autobot/providers/registry_spec.cr
@@ -27,7 +27,7 @@ describe Autobot::Providers do
     end
 
     it "matches Gemini" do
-      spec = Autobot::Providers.find_by_model("gemini-pro")
+      spec = Autobot::Providers.find_by_model("gemini-2.5-flash")
       spec.should_not be_nil
       spec.try(&.name).should eq("gemini")
     end

--- a/spec/autobot/session/session_spec.cr
+++ b/spec/autobot/session/session_spec.cr
@@ -154,8 +154,6 @@ describe Autobot::Session::Manager do
 
     manager.delete("delete:me").should be_true
     manager.delete("delete:me").should be_false # Already deleted
-
-
   ensure
     FileUtils.rm_rf(tmp) if tmp
   end

--- a/src/autobot/cli/config_generator.cr
+++ b/src/autobot/cli/config_generator.cr
@@ -134,7 +134,7 @@ module Autobot
         when "openai"     then "openai/gpt-4"
         when "deepseek"   then "deepseek/deepseek-chat"
         when "groq"       then "groq/mixtral-8x7b-32768"
-        when "gemini"     then "gemini/gemini-pro"
+        when "gemini"     then "gemini/gemini-2.5-flash"
         when "kimi"       then "kimi/kimi-for-coding"
         when "openrouter" then "openrouter/auto"
         else


### PR DESCRIPTION
## Summary

The interactive setup (`autobot setup`) generated configs with `gemini/gemini-pro` as the default Gemini model. Google's v1main API no longer serves that model, so the very first agent call fails with:

```
API error: models/gemini-pro is not found for API version v1main, or is not supported for generateContent.
```

Switching the default to `gemini/gemini-2.5-flash` matches what `docs/gemini.md` and `docs/providers.md` already recommend.

## Changes

- [x] `src/autobot/cli/config_generator.cr`: default model for `gemini` is now `gemini/gemini-2.5-flash`
- [x] `spec/autobot/providers/registry_spec.cr`: keyword-match test uses a current model id

## Notes

- Existing user configs are not migrated — anyone who already has `model: "gemini/gemini-pro"` in their `config.yml` still needs to update it manually.
- Refs #63 (left open so the reporter can confirm)