### PR TITLE
fix(tools): prevent deadlock when executed commands spawn daemons

### DIFF
--- a/src/autobot/tools/exec.cr
+++ b/src/autobot/tools/exec.cr
@@ -185,12 +185,14 @@ module Autobot
 
         timed_out, status = wait_for_process(process, completed)
 
+        # Close read ends to break any blocking io.read in background fibers
+        # when daemon processes hold the write ends open
+        stdout_read.close unless stdout_read.closed?
+        stderr_read.close unless stderr_read.closed?
+
         # Collect limited outputs
         stdout_text = stdout_channel.receive
         stderr_text = stderr_channel.receive
-
-        stdout_read.close
-        stderr_read.close
 
         build_command_result(stdout_text, stderr_text, status, timed_out)
       end
@@ -212,7 +214,7 @@ module Autobot
 
         buffer.to_s
       rescue
-        ""
+        buffer.to_s
       end
 
       private def build_command_result(stdout_text : String, stderr_text : String, status : Process::Status?, timed_out : Bool) : String


### PR DESCRIPTION
## Description
When Autobot uses the `exec` tool, if the executed command spawns a background daemon (such as `postgres` via `pg_ctl start`), that daemon inherits the standard output and standard error file descriptors from the shell. 

Because Autobot's process executor was waiting indefinitely for the read channels to close (EOF), and the long-running background daemon never closed those write pipes, the agent's main event loop would hang permanently. 

## Fix
This PR ensures that the read ends of the `stdout` and `stderr` pipes are explicitly closed by the parent process immediately after the main process completes. This forcefully interrupts any lingering blocking reads from background fibers and safely returns the captured output up to that point.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>