### PR TITLE
fix(tools): respect sandbox: none config in SandboxExecutor

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -227,16 +227,16 @@ autobot agent --sandbox docker
 
 ## Development
 
-### Running Without Sandbox (Tests)
+### Running Without Sandbox (Tests and Development)
 
-Tests automatically disable sandboxing:
+Tests or configurations with `sandbox: none` disable sandboxing. If a workspace is configured but sandboxing is disabled, operations run directly on the host filesystem:
 
 ```crystal
-# Tests pass nil workspace to SandboxExecutor
-executor = SandboxExecutor.new(nil)
+# Initialize SandboxExecutor with sandboxed: false
+executor = SandboxExecutor.new(workspace, sandboxed: false)
 tool = ReadFileTool.new(executor)
 
-# Tool uses direct file operations (fast, no overhead)
+# Tool uses direct file operations on the host filesystem
 tool.execute({"path" => JSON::Any.new("test.txt")})  # Direct File.read
 ```
 

--- a/spec/autobot/tools/sandbox_executor_spec.cr
+++ b/spec/autobot/tools/sandbox_executor_spec.cr
@@ -1,0 +1,36 @@
+require "../../spec_helper"
+
+describe Autobot::Tools::SandboxExecutor do
+  it "bypasses sandbox for filesystem operations when sandboxed is false" do
+    tmp = TestHelper.tmp_dir
+    file = tmp / "test.txt"
+    File.write(file, "hello sandbox none")
+
+    # Initialize with sandboxed: false
+    executor = Autobot::Tools::SandboxExecutor.new(tmp, sandboxed: false)
+    executor.sandboxed?.should be_false
+
+    # read_file should read directly
+    result = executor.read_file(file.to_s)
+    result.success?.should be_true
+    result.content.should eq("hello sandbox none")
+
+    # write_file should write directly
+    write_result = executor.write_file((tmp / "written.txt").to_s, "direct write")
+    write_result.success?.should be_true
+    File.read(tmp / "written.txt").should eq("direct write")
+
+    # list_dir should list directly
+    list_result = executor.list_dir(tmp.to_s)
+    list_result.success?.should be_true
+    list_result.content.should contain("test.txt")
+    list_result.content.should contain("written.txt")
+
+    # exec should execute directly
+    exec_result = executor.exec("echo hello direct")
+    exec_result.success?.should be_true
+    exec_result.content.strip.should eq("hello direct")
+  ensure
+    FileUtils.rm_rf(tmp) if tmp
+  end
+end

--- a/src/autobot/tools/sandbox_executor.cr
+++ b/src/autobot/tools/sandbox_executor.cr
@@ -14,11 +14,13 @@ module Autobot
     class SandboxExecutor
       MAX_FILE_SIZE = 1_048_576
 
-      def initialize(@workspace : Path?)
+      getter? sandboxed : Bool = true
+
+      def initialize(@workspace : Path?, @sandboxed : Bool = true)
       end
 
       def read_file(path : String) : ToolResult
-        if workspace = @workspace
+        if @sandboxed && (workspace = @workspace)
           read_file_via_sandbox_exec(path, workspace)
         else
           read_file_direct(path)
@@ -30,7 +32,7 @@ module Autobot
       # Read a file and return base64-encoded contents.
       # Safe for binary files (images, GIFs, documents).
       def read_file_base64(path : String) : ToolResult
-        if workspace = @workspace
+        if @sandboxed && (workspace = @workspace)
           success, output = Sandbox.read_file_base64(path, workspace)
           success ? ToolResult.success(output) : ToolResult.error(output)
         else
@@ -41,7 +43,7 @@ module Autobot
       end
 
       def write_file(path : String, content : String) : ToolResult
-        if workspace = @workspace
+        if @sandboxed && (workspace = @workspace)
           write_file_via_sandbox_exec(path, content, workspace)
         else
           write_file_direct(path, content)
@@ -51,7 +53,7 @@ module Autobot
       end
 
       def list_dir(path : String) : ToolResult
-        if workspace = @workspace
+        if @sandboxed && (workspace = @workspace)
           list_dir_via_sandbox_exec(path, workspace)
         else
           list_dir_direct(path)
@@ -61,7 +63,7 @@ module Autobot
       end
 
       def exec(command : String, timeout : Int32 = 60) : ToolResult
-        if workspace = @workspace
+        if @sandboxed && (workspace = @workspace)
           exec_via_sandbox_exec(command, timeout, workspace)
         else
           exec_direct(command, timeout)

--- a/src/autobot/tools/tools.cr
+++ b/src/autobot/tools/tools.cr
@@ -45,7 +45,7 @@ module Autobot
       end
 
       # Create centralized sandbox executor
-      executor = SandboxExecutor.new(workspace)
+      executor = SandboxExecutor.new(workspace, sandboxed)
 
       # Register tools
       register_filesystem_tools(registry, executor)
@@ -75,7 +75,8 @@ module Autobot
     ) : Registry
       registry = Registry.new(rate_limiter: rate_limiter)
 
-      executor = SandboxExecutor.new(workspace)
+      sandboxed = sandbox_config.downcase != "none"
+      executor = SandboxExecutor.new(workspace, sandboxed)
 
       register_filesystem_tools(registry, executor)
       register_exec_tool(registry, executor, exec_timeout, exec_deny_patterns,


### PR DESCRIPTION
This pull request ensures that filesystem and execution tools correctly bypass the sandboxing mechanism when `sandbox` is configured as `none`. Previously, SandboxExecutor would still attempt to sandbox operations if a workspace was configured.

### Changes:
- Added a `sandboxed` flag in `SandboxExecutor` to control whether sandboxing is applied.
- Updated all execution and filesystem operations in `SandboxExecutor` to fall back to direct executions when `sandboxed` is false.
- Initialized `SandboxExecutor` in `tools.cr` with the resolved sandbox setting (for both main and subagent registries).
- Added a unit spec `spec/autobot/tools/sandbox_executor_spec.cr` to verify that `SandboxExecutor` correctly bypasses the sandbox and runs direct operations when `sandboxed` is set to `false`.

### AI Assistance Disclosure
This pull request was prepared with the assistance of Gemini AI. The user (Rénich) has directed, reviewed, and tested these changes, and takes full responsibility for the code.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>