### PR TITLE
fix(tools): prevent daemon execution deadlocks

### DIFF
--- a/spec/autobot/tools/exec_spec.cr
+++ b/spec/autobot/tools/exec_spec.cr
@@ -181,12 +181,12 @@ describe Autobot::Tools::ExecTool do
     it "does not hang on background daemon processes" do
       tool = Autobot::Tools::ExecTool.new(executor: create_test_executor, sandbox_config: "none")
       start = Time.instant
-      result = tool.execute({"command" => JSON::Any.new("echo started; sleep 5 &")})
+      result = tool.execute({"command" => JSON::Any.new("echo started; sleep 3 &")})
       elapsed = Time.instant - start
 
       result.success?.should be_true
       result.content.strip.should start_with("started")
-      (elapsed < 2.seconds).should be_true
+      (elapsed < 1.second).should be_true
     end
   end
 end

--- a/spec/autobot/tools/exec_spec.cr
+++ b/spec/autobot/tools/exec_spec.cr
@@ -176,4 +176,17 @@ describe Autobot::Tools::ExecTool do
       result.content.should contain("Command blocked")
     end
   end
+
+  describe "daemon execution handling" do
+    it "does not hang on background daemon processes" do
+      tool = Autobot::Tools::ExecTool.new(executor: create_test_executor, sandbox_config: "none")
+      start = Time.instant
+      result = tool.execute({"command" => JSON::Any.new("echo started; sleep 5 &")})
+      elapsed = Time.instant - start
+
+      result.success?.should be_true
+      result.content.strip.should start_with("started")
+      (elapsed < 2.seconds).should be_true
+    end
+  end
 end

--- a/spec/autobot/tools/sandbox_executor_spec.cr
+++ b/spec/autobot/tools/sandbox_executor_spec.cr
@@ -3,29 +3,23 @@ require "../../spec_helper"
 describe Autobot::Tools::SandboxExecutor do
   describe "#exec direct execution" do
     it "returns the captured output for a simple command" do
-      # Arrange
       executor = Autobot::Tools::SandboxExecutor.new(nil)
 
-      # Act
       result = executor.exec("echo hello")
 
-      # Assert
       result.success?.should be_true
       result.content.strip.should eq("hello")
     end
 
     it "does not hang when a command leaves a daemon holding the pipe open" do
-      # Arrange — the daemon keeps the stdout write end open after `sh` exits.
-      # Without closing the read ends, the reader fibers block until the daemon
-      # exits (~3s here), so the elapsed time catches the regression.
       executor = Autobot::Tools::SandboxExecutor.new(nil)
 
-      # Act
+      # The daemon holds the pipe open after `sh` exits; without the fix the
+      # reader fibers block until it dies (~3s), so timing catches the regression.
       start = Time.instant
       result = executor.exec("echo started; sleep 3 &")
       elapsed = Time.instant - start
 
-      # Assert
       result.success?.should be_true
       result.content.strip.should start_with("started")
       (elapsed < 1.second).should be_true

--- a/spec/autobot/tools/sandbox_executor_spec.cr
+++ b/spec/autobot/tools/sandbox_executor_spec.cr
@@ -1,0 +1,34 @@
+require "../../spec_helper"
+
+describe Autobot::Tools::SandboxExecutor do
+  describe "#exec direct execution" do
+    it "returns the captured output for a simple command" do
+      # Arrange
+      executor = Autobot::Tools::SandboxExecutor.new(nil)
+
+      # Act
+      result = executor.exec("echo hello")
+
+      # Assert
+      result.success?.should be_true
+      result.content.strip.should eq("hello")
+    end
+
+    it "does not hang when a command leaves a daemon holding the pipe open" do
+      # Arrange — the daemon keeps the stdout write end open after `sh` exits.
+      # Without closing the read ends, the reader fibers block until the daemon
+      # exits (~3s here), so the elapsed time catches the regression.
+      executor = Autobot::Tools::SandboxExecutor.new(nil)
+
+      # Act
+      start = Time.instant
+      result = executor.exec("echo started; sleep 3 &")
+      elapsed = Time.instant - start
+
+      # Assert
+      result.success?.should be_true
+      result.content.strip.should start_with("started")
+      (elapsed < 1.second).should be_true
+    end
+  end
+end

--- a/src/autobot/tools/sandbox.cr
+++ b/src/autobot/tools/sandbox.cr
@@ -23,6 +23,7 @@ module Autobot
       MKDIR_TIMEOUT         =         5
       MAX_WRITE_OUTPUT      =    10_000
       MAX_LIST_OUTPUT       =   100_000
+      DEFAULT_MAX_OUTPUT    =    10_000
 
       enum Type
         Bubblewrap
@@ -93,7 +94,7 @@ module Autobot
         command : String,
         workspace : Path,
         timeout : Int32,
-        max_output_size : Int32 = 10_000,
+        max_output_size : Int32 = DEFAULT_MAX_OUTPUT,
       ) : {Process::Status, String, String}
         Log.debug { "Executing shell command in sandbox: #{command}" }
         run_in_sandbox(["sh", "-c", command], workspace, timeout, max_output_size)
@@ -106,7 +107,7 @@ module Autobot
         args : Array(String),
         workspace : Path,
         timeout : Int32,
-        max_output_size : Int32 = 10_000,
+        max_output_size : Int32 = DEFAULT_MAX_OUTPUT,
       ) : {Process::Status, String, String}
         Log.debug { "Executing program in sandbox: #{program} #{args.join(" ")}" }
         run_in_sandbox([program] + args, workspace, timeout, max_output_size)
@@ -154,7 +155,7 @@ module Autobot
         args.push("--")
         args.concat(cmd_args)
 
-        run_sandboxed_command("bwrap", args, timeout, max_output_size)
+        capture_command("bwrap", args, timeout, max_output_size)
       end
 
       private def self.run_in_docker(
@@ -181,7 +182,7 @@ module Autobot
         args << image
         args.concat(cmd_args)
 
-        run_sandboxed_command("docker", args, timeout, max_output_size)
+        capture_command("docker", args, timeout, max_output_size)
       end
 
       # Forward explicitly allowed environment variables to Docker container.
@@ -253,17 +254,20 @@ module Autobot
         false
       end
 
-      private def self.run_sandboxed_command(
-        sandbox_cmd : String,
+      # Runs a process, capturing stdout/stderr through pipes with a timeout.
+      # The read ends are closed once the process settles so reader fibers never
+      # block on daemons that inherit and keep the pipe write ends open.
+      def self.capture_command(
+        command : String,
         args : Array(String),
         timeout : Int32,
-        max_output_size : Int32,
+        max_output_size : Int32 = DEFAULT_MAX_OUTPUT,
       ) : {Process::Status, String, String}
         stdout_read, stdout_write = IO.pipe
         stderr_read, stderr_write = IO.pipe
 
         process = Process.new(
-          sandbox_cmd,
+          command,
           args,
           output: stdout_write,
           error: stderr_write

--- a/src/autobot/tools/sandbox.cr
+++ b/src/autobot/tools/sandbox.cr
@@ -286,11 +286,11 @@ module Autobot
 
         status = wait_for_process(process, completed, timeout)
 
+        stdout_read.close unless stdout_read.closed?
+        stderr_read.close unless stderr_read.closed?
+
         stdout_text = stdout_channel.receive
         stderr_text = stderr_channel.receive
-
-        stdout_read.close
-        stderr_read.close
 
         {status, stdout_text, stderr_text}
       end
@@ -312,7 +312,7 @@ module Autobot
 
         buffer.to_s
       rescue
-        ""
+        buffer.to_s
       end
 
       private def self.wait_for_process(

--- a/src/autobot/tools/sandbox_executor.cr
+++ b/src/autobot/tools/sandbox_executor.cr
@@ -190,7 +190,7 @@ module Autobot
           io = IO::Memory.new
           begin
             IO.copy(stdout_read, io)
-          rescue ex : IO::Error
+          rescue IO::Error
             # stream closed
           ensure
             stdout_channel.send(io.to_s)
@@ -201,7 +201,7 @@ module Autobot
           io = IO::Memory.new
           begin
             IO.copy(stderr_read, io)
-          rescue ex : IO::Error
+          rescue IO::Error
             # stream closed
           ensure
             stderr_channel.send(io.to_s)

--- a/src/autobot/tools/sandbox_executor.cr
+++ b/src/autobot/tools/sandbox_executor.cr
@@ -93,17 +93,7 @@ module Autobot
 
       private def exec_via_sandbox_exec(command : String, timeout : Int32, workspace : Path) : ToolResult
         status, stdout, stderr = Sandbox.exec(command, workspace, timeout)
-
-        parts = [] of String
-        parts << stdout unless stdout.empty?
-        parts << "STDERR:\n#{stderr}" unless stderr.empty?
-
-        if !status.success? && status.exit_code != Sandbox::TIMEOUT_EXIT_CODE
-          parts << "\nExit code: #{status.exit_code}"
-        end
-
-        data = parts.empty? ? "[no output]" : parts.join("\n")
-        ToolResult.success(data)
+        build_exec_result(status, stdout, stderr)
       end
 
       # Direct execution (tests and non-sandbox mode)
@@ -171,67 +161,18 @@ module Autobot
       end
 
       private def exec_direct(command : String, timeout : Int32) : ToolResult
-        stdout_read, stdout_write = IO.pipe
-        stderr_read, stderr_write = IO.pipe
+        status, stdout, stderr = Sandbox.capture_command("sh", ["-c", command], timeout)
+        build_exec_result(status, stdout, stderr)
+      end
 
-        process = Process.new(
-          "sh", ["-c", command],
-          output: stdout_write,
-          error: stderr_write
-        )
-
-        stdout_write.close
-        stderr_write.close
-
-        stdout_channel = Channel(String).new(1)
-        stderr_channel = Channel(String).new(1)
-
-        spawn do
-          io = IO::Memory.new
-          begin
-            IO.copy(stdout_read, io)
-          rescue IO::Error
-          ensure
-            stdout_channel.send(io.to_s)
-          end
-        end
-
-        spawn do
-          io = IO::Memory.new
-          begin
-            IO.copy(stderr_read, io)
-          rescue IO::Error
-          ensure
-            stderr_channel.send(io.to_s)
-          end
-        end
-
-        completed = Channel(Process::Status).new(1)
-        spawn do
-          status = process.wait
-          completed.send(status)
-        end
-
-        select
-        when completed.receive
-        when timeout(timeout.seconds)
-          process.signal(Signal::TERM)
-          sleep 0.5.seconds
-          process.signal(Signal::KILL) unless process.terminated?
-          process.wait
-        end
-
-        # Close read ends to break any blocking io.read in background fibers
-        # when daemon processes hold the write ends open
-        stdout_read.close unless stdout_read.closed?
-        stderr_read.close unless stderr_read.closed?
-
-        stdout_text = stdout_channel.receive
-        stderr_text = stderr_channel.receive
-
+      private def build_exec_result(status : Process::Status, stdout : String, stderr : String) : ToolResult
         parts = [] of String
-        parts << stdout_text unless stdout_text.empty?
-        parts << "STDERR:\n#{stderr_text}" unless stderr_text.empty?
+        parts << stdout unless stdout.empty?
+        parts << "STDERR:\n#{stderr}" unless stderr.empty?
+
+        if !status.success? && status.exit_code != Sandbox::TIMEOUT_EXIT_CODE
+          parts << "\nExit code: #{status.exit_code}"
+        end
 
         data = parts.empty? ? "[no output]" : parts.join("\n")
         ToolResult.success(data)

--- a/src/autobot/tools/sandbox_executor.cr
+++ b/src/autobot/tools/sandbox_executor.cr
@@ -191,7 +191,6 @@ module Autobot
           begin
             IO.copy(stdout_read, io)
           rescue IO::Error
-            # stream closed
           ensure
             stdout_channel.send(io.to_s)
           end
@@ -202,7 +201,6 @@ module Autobot
           begin
             IO.copy(stderr_read, io)
           rescue IO::Error
-            # stream closed
           ensure
             stderr_channel.send(io.to_s)
           end
@@ -216,7 +214,6 @@ module Autobot
 
         select
         when completed.receive
-          # Process completed
         when timeout(timeout.seconds)
           process.signal(Signal::TERM)
           sleep 0.5.seconds

--- a/src/autobot/tools/sandbox_executor.cr
+++ b/src/autobot/tools/sandbox_executor.cr
@@ -186,8 +186,27 @@ module Autobot
         stdout_channel = Channel(String).new(1)
         stderr_channel = Channel(String).new(1)
 
-        spawn { stdout_channel.send(stdout_read.gets_to_end) }
-        spawn { stderr_channel.send(stderr_read.gets_to_end) }
+        spawn do
+          io = IO::Memory.new
+          begin
+            IO.copy(stdout_read, io)
+          rescue ex : IO::Error
+            # stream closed
+          ensure
+            stdout_channel.send(io.to_s)
+          end
+        end
+
+        spawn do
+          io = IO::Memory.new
+          begin
+            IO.copy(stderr_read, io)
+          rescue ex : IO::Error
+            # stream closed
+          ensure
+            stderr_channel.send(io.to_s)
+          end
+        end
 
         completed = Channel(Process::Status).new(1)
         spawn do
@@ -205,11 +224,13 @@ module Autobot
           process.wait
         end
 
+        # Close read ends to break any blocking io.read in background fibers
+        # when daemon processes hold the write ends open
+        stdout_read.close unless stdout_read.closed?
+        stderr_read.close unless stderr_read.closed?
+
         stdout_text = stdout_channel.receive
         stderr_text = stderr_channel.receive
-
-        stdout_read.close
-        stderr_read.close
 
         parts = [] of String
         parts << stdout_text unless stdout_text.empty?


### PR DESCRIPTION
This pull request addresses the daemon execution deadlock issue where background daemon processes keep stdout/stderr write ends open indefinitely, causing reader fibers to block on gets/reads even after the main process has completed.

### Changes:
- Updated reader fibers in `SandboxExecutor.exec_direct` to use a loop copy and rescue `IO::Error: Closed stream` to ensure they always send the partial output accumulated in `IO::Memory`.
- Updated `Sandbox.read_limited_output` to rescue `IO::Error: Closed stream` and return the accumulated output (`buffer.to_s`) rather than an empty string `""`.
- Closed read ends of the stdout/stderr pipes immediately when wait completion completes (both in `exec_direct` and `run_sandboxed_command`).
- Added a spec `spec/autobot/tools/exec_spec.cr` that tests executing background daemon tasks (like `echo started; sleep 5 &`) to ensure they do not hang and return control to the caller immediately with the expected partial output.

### AI Assistance Disclosure
This pull request was prepared with the assistance of Gemini AI. The user (Rénich) has directed, reviewed, and tested these changes, and takes full responsibility for the code.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>