### PR TITLE
Fix crash in HTTPProvider on non-JSON response

### DIFF
--- a/spec/autobot/providers/http_provider_spec.cr
+++ b/spec/autobot/providers/http_provider_spec.cr
@@ -13,7 +13,12 @@ class TestableHttpProvider < Autobot::Providers::HttpProvider
   end
 
   def test_parse_compatible_response(body : String) : Autobot::Providers::Response
-    parse_compatible_response(body)
+    response = HTTP::Client::Response.new(200, body: body)
+    parse_compatible_response(response)
+  end
+
+  def test_parse_compatible_response_direct(response : HTTP::Client::Response) : Autobot::Providers::Response
+    parse_compatible_response(response)
   end
 
   def test_convert_content_for_anthropic(content : JSON::Any) : JSON::Any
@@ -29,7 +34,12 @@ class TestableHttpProvider < Autobot::Providers::HttpProvider
   end
 
   def test_parse_anthropic_response(body : String) : Autobot::Providers::Response
-    parse_anthropic_response(body)
+    response = HTTP::Client::Response.new(200, body: body)
+    parse_anthropic_response(response)
+  end
+
+  def test_parse_anthropic_response_direct(response : HTTP::Client::Response) : Autobot::Providers::Response
+    parse_anthropic_response(response)
   end
 
   def test_max_tokens_param_name(model : String) : String
@@ -232,6 +242,22 @@ describe Autobot::Providers::HttpProvider do
       response = provider.test_parse_compatible_response(body)
       response.has_tool_calls?.should be_true
       response.tool_calls.first.extra_content.should be_nil
+    end
+
+    it "handles non-JSON error response with non-200 status (e.g. Forbidden)" do
+      http_response = HTTP::Client::Response.new(403, body: "Forbidden")
+      response = provider.test_parse_compatible_response_direct(http_response)
+      response.finish_reason.should eq("error")
+      response.content.not_nil!.should contain("HTTP request failed with status 403")
+      response.content.not_nil!.should contain("Forbidden")
+    end
+
+    it "handles non-JSON body with 200 status gracefully" do
+      http_response = HTTP::Client::Response.new(200, body: "Something went wrong but HTTP 200")
+      response = provider.test_parse_compatible_response_direct(http_response)
+      response.finish_reason.should eq("error")
+      response.content.not_nil!.should contain("Failed to parse API response as JSON (HTTP 200)")
+      response.content.not_nil!.should contain("Something went wrong but HTTP 200")
     end
   end
 

--- a/src/autobot/providers/http_provider.cr
+++ b/src/autobot/providers/http_provider.cr
@@ -115,28 +115,12 @@ module Autobot
       end
 
       private def parse_compatible_response(response : HTTP::Client::Response) : Response
-        unless response.success?
-          begin
-            json = JSON.parse(response.body)
-            if error = extract_error(json)
-              return Response.new(content: "API error (HTTP #{response.status_code}): #{error}", finish_reason: "error")
-            end
-          rescue
+        json = resolve_json(response) do |body|
+          if error = extract_error(body)
+            Response.new(content: "API error (HTTP #{response.status_code}): #{error}", finish_reason: "error")
           end
-          return Response.new(
-            content: "HTTP request failed with status #{response.status_code}: #{response.body}",
-            finish_reason: "error"
-          )
         end
-
-        begin
-          json = JSON.parse(response.body)
-        rescue ex
-          return Response.new(
-            content: "Failed to parse API response as JSON (HTTP #{response.status_code}): #{ex.message}. Body: #{response.body}",
-            finish_reason: "error"
-          )
-        end
+        return json if json.is_a?(Response)
 
         if error = extract_error(json)
           return Response.new(content: "API error: #{error}", finish_reason: "error")
@@ -371,28 +355,8 @@ module Autobot
       end
 
       private def parse_anthropic_response(response : HTTP::Client::Response) : Response
-        unless response.success?
-          begin
-            json = JSON.parse(response.body)
-            if error_response = parse_anthropic_error(json, response.body)
-              return error_response
-            end
-          rescue
-          end
-          return Response.new(
-            content: "HTTP request failed with status #{response.status_code}: #{response.body}",
-            finish_reason: "error"
-          )
-        end
-
-        begin
-          json = JSON.parse(response.body)
-        rescue ex
-          return Response.new(
-            content: "Failed to parse API response as JSON (HTTP #{response.status_code}): #{ex.message}. Body: #{response.body}",
-            finish_reason: "error"
-          )
-        end
+        json = resolve_json(response) { |body| parse_anthropic_error(body, response.body) }
+        return json if json.is_a?(Response)
 
         if error_response = parse_anthropic_error(json, response.body)
           return error_response
@@ -406,6 +370,47 @@ module Autobot
         return nil unless json["type"]?.try(&.as_s?) == "error"
         msg = json["error"]?.try { |error| error["message"]?.try(&.as_s?) } || body
         Response.new(content: "API error: #{msg}", finish_reason: "error")
+      end
+
+      # Parses the response body into JSON, or returns an error Response when
+      # the request failed or the body is not valid JSON. On a failed status the
+      # block may surface a provider-specific error from the parsed body before
+      # falling back to a generic status message.
+      private def resolve_json(response : HTTP::Client::Response, & : JSON::Any -> Response?) : JSON::Any | Response
+        unless response.success?
+          if json = parse_json?(response.body)
+            if error_response = yield json
+              return error_response
+            end
+          end
+          return http_failure_response(response)
+        end
+
+        begin
+          JSON.parse(response.body)
+        rescue ex
+          json_parse_error_response(response, ex)
+        end
+      end
+
+      private def parse_json?(body : String) : JSON::Any?
+        JSON.parse(body)
+      rescue
+        nil
+      end
+
+      private def http_failure_response(response : HTTP::Client::Response) : Response
+        Response.new(
+          content: "HTTP request failed with status #{response.status_code}: #{response.body}",
+          finish_reason: "error",
+        )
+      end
+
+      private def json_parse_error_response(response : HTTP::Client::Response, error : Exception) : Response
+        Response.new(
+          content: "Failed to parse API response as JSON (HTTP #{response.status_code}): #{error.message}. Body: #{response.body}",
+          finish_reason: "error",
+        )
       end
 
       # Extracts an error message from an OpenAI-compatible response.

--- a/src/autobot/providers/http_provider.cr
+++ b/src/autobot/providers/http_provider.cr
@@ -85,7 +85,7 @@ module Autobot
 
         Log.debug { "POST #{url} model=#{model}" }
         response = http_post(url, headers, body.to_json)
-        parse_compatible_response(response.body)
+        parse_compatible_response(response)
       end
 
       private def build_compatible_body(messages, tools, model, max_tokens, temperature, spec)
@@ -114,8 +114,29 @@ module Autobot
         body
       end
 
-      private def parse_compatible_response(body : String) : Response
-        json = JSON.parse(body)
+      private def parse_compatible_response(response : HTTP::Client::Response) : Response
+        unless response.success?
+          begin
+            json = JSON.parse(response.body)
+            if error = extract_error(json)
+              return Response.new(content: "API error (HTTP #{response.status_code}): #{error}", finish_reason: "error")
+            end
+          rescue
+          end
+          return Response.new(
+            content: "HTTP request failed with status #{response.status_code}: #{response.body}",
+            finish_reason: "error"
+          )
+        end
+
+        begin
+          json = JSON.parse(response.body)
+        rescue ex
+          return Response.new(
+            content: "Failed to parse API response as JSON (HTTP #{response.status_code}): #{ex.message}. Body: #{response.body}",
+            finish_reason: "error"
+          )
+        end
 
         if error = extract_error(json)
           return Response.new(content: "API error: #{error}", finish_reason: "error")
@@ -158,7 +179,7 @@ module Autobot
 
         Log.debug { "POST #{url} model=#{model} (anthropic)" }
         response = http_post(url, headers, body.to_json)
-        parse_anthropic_response(response.body)
+        parse_anthropic_response(response)
       end
 
       private def build_anthropic_body(messages, tools, model, max_tokens, temperature)
@@ -349,9 +370,31 @@ module Autobot
         items[-1] = JSON::Any.new(updated)
       end
 
-      private def parse_anthropic_response(body : String) : Response
-        json = JSON.parse(body)
-        if error_response = parse_anthropic_error(json, body)
+      private def parse_anthropic_response(response : HTTP::Client::Response) : Response
+        unless response.success?
+          begin
+            json = JSON.parse(response.body)
+            if error_response = parse_anthropic_error(json, response.body)
+              return error_response
+            end
+          rescue
+          end
+          return Response.new(
+            content: "HTTP request failed with status #{response.status_code}: #{response.body}",
+            finish_reason: "error"
+          )
+        end
+
+        begin
+          json = JSON.parse(response.body)
+        rescue ex
+          return Response.new(
+            content: "Failed to parse API response as JSON (HTTP #{response.status_code}): #{ex.message}. Body: #{response.body}",
+            finish_reason: "error"
+          )
+        end
+
+        if error_response = parse_anthropic_error(json, response.body)
           return error_response
         end
 


### PR DESCRIPTION
This PR resolves the issue where `HttpProvider` crashes with `Unexpected char 'F'` on receiving non-JSON responses from upstream APIs (e.g. during rate limiting or outages).

### Changes
- Updated internal parsing helper signatures to receive the raw `HTTP::Client::Response` rather than just the string body.
- Validated `response.success?` before attempting to parse.
- Wrapped `JSON.parse` in a `begin/rescue` block to handle malformed JSON bodies gracefully.
- Added comprehensive unit tests in `spec/autobot/providers/http_provider_spec.cr`.

Fixes #76.

---
Assisted-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>