### PR TITLE
Scrub all ToolResult content to ensure valid UTF-8

### DIFF
--- a/spec/autobot/tools/base_spec.cr
+++ b/spec/autobot/tools/base_spec.cr
@@ -189,3 +189,26 @@ describe Autobot::Tools::PropertySchema do
     end
   end
 end
+
+describe Autobot::Tools::ToolResult do
+  it "scrubs invalid UTF-8 bytes from success content" do
+    invalid_str = "hello \xff world"
+    result = Autobot::Tools::ToolResult.success(invalid_str)
+    result.content.should_not contain("\xff")
+    result.content.should contain("hello \u{FFFD} world")
+  end
+
+  it "scrubs invalid UTF-8 bytes from error message" do
+    invalid_str = "error \xff details"
+    result = Autobot::Tools::ToolResult.error(invalid_str)
+    result.content.should_not contain("\xff")
+    result.content.should contain("error \u{FFFD} details")
+  end
+
+  it "scrubs invalid UTF-8 bytes from access denied message" do
+    invalid_str = "denied \xff reason"
+    result = Autobot::Tools::ToolResult.access_denied(invalid_str)
+    result.content.should_not contain("\xff")
+    result.content.should contain("denied \u{FFFD} reason")
+  end
+end

--- a/src/autobot/tools/result.cr
+++ b/src/autobot/tools/result.cr
@@ -11,7 +11,8 @@ module Autobot
       getter status : Status
       getter content : String
 
-      def initialize(@status : Status, @content : String)
+      def initialize(@status : Status, content : String)
+        @content = content.scrub
       end
 
       def self.success(content : String) : ToolResult


### PR DESCRIPTION
This PR resolves the issue where `ToolResult` content containing raw non-UTF-8 bytes (such as from terminal escape codes or warning messages) was passed directly to the LLM API, causing strict JSON validation failures.

### Changes
- Updated `ToolResult` to automatically call `String#scrub` during initialization.
- Replaces any invalid byte sequences with the standard unicode replacement character (`\u{FFFD}`).
- Added unit tests in `spec/autobot/tools/base_spec.cr`.

Fixes #78.

---
*Note: This PR was drafted and posted by Gemini AI. The contribution was co-developed with Gemini AI under the direction, review, and responsibility of Rénich Bon Ćirić.*