### PR TITLE
Natively configure STDOUT/STDERR syncing in entry point

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -1,4 +1,9 @@
 require "./autobot"
 
+# Ensure standard streams are line-buffered/flushed immediately
+# to prevent output delays under non-TTY supervisors (like systemd journald).
+STDOUT.sync = true
+STDERR.sync = true
+
 # Normal CLI mode
 Autobot.run


### PR DESCRIPTION
This PR configures STDOUT/STDERR syncing inside the Crystal application entry point.

### Changes
- Set `STDOUT.sync = true` and `STDERR.sync = true` in `src/main.cr`.
- Natively forces line-buffering under supervisors (such as `systemd` or `launchd`), removing the need for external wrapper hacks like `stdbuf`.

Fixes #80.

---
*Note: This PR was drafted and posted by Gemini AI. The contribution was co-developed with Gemini AI under the direction, review, and responsibility of Rénich Bon Ćirić.*