### PR TITLE
fix(tools): try all resolved IP addresses in WebFetchTool

### DIFF
--- a/spec/autobot/providers/http_provider_spec.cr
+++ b/spec/autobot/providers/http_provider_spec.cr
@@ -248,16 +248,18 @@ describe Autobot::Providers::HttpProvider do
       http_response = HTTP::Client::Response.new(403, body: "Forbidden")
       response = provider.test_parse_compatible_response_direct(http_response)
       response.finish_reason.should eq("error")
-      response.content.not_nil!.should contain("HTTP request failed with status 403")
-      response.content.not_nil!.should contain("Forbidden")
+      content = response.content.as(String)
+      content.should contain("HTTP request failed with status 403")
+      content.should contain("Forbidden")
     end
 
     it "handles non-JSON body with 200 status gracefully" do
       http_response = HTTP::Client::Response.new(200, body: "Something went wrong but HTTP 200")
       response = provider.test_parse_compatible_response_direct(http_response)
       response.finish_reason.should eq("error")
-      response.content.not_nil!.should contain("Failed to parse API response as JSON (HTTP 200)")
-      response.content.not_nil!.should contain("Something went wrong but HTTP 200")
+      content = response.content.as(String)
+      content.should contain("Failed to parse API response as JSON (HTTP 200)")
+      content.should contain("Something went wrong but HTTP 200")
     end
   end
 

--- a/spec/autobot/providers/http_provider_spec.cr
+++ b/spec/autobot/providers/http_provider_spec.cr
@@ -248,18 +248,24 @@ describe Autobot::Providers::HttpProvider do
       http_response = HTTP::Client::Response.new(403, body: "Forbidden")
       response = provider.test_parse_compatible_response_direct(http_response)
       response.finish_reason.should eq("error")
-      content = response.content.as(String)
-      content.should contain("HTTP request failed with status 403")
-      content.should contain("Forbidden")
+      if content = response.content
+        content.should contain("HTTP request failed with status 403")
+        content.should contain("Forbidden")
+      else
+        fail("Expected content to not be nil")
+      end
     end
 
     it "handles non-JSON body with 200 status gracefully" do
       http_response = HTTP::Client::Response.new(200, body: "Something went wrong but HTTP 200")
       response = provider.test_parse_compatible_response_direct(http_response)
       response.finish_reason.should eq("error")
-      content = response.content.as(String)
-      content.should contain("Failed to parse API response as JSON (HTTP 200)")
-      content.should contain("Something went wrong but HTTP 200")
+      if content = response.content
+        content.should contain("Failed to parse API response as JSON (HTTP 200)")
+        content.should contain("Something went wrong but HTTP 200")
+      else
+        fail("Expected content to not be nil")
+      end
     end
   end
 

--- a/src/autobot/tools/web.cr
+++ b/src/autobot/tools/web.cr
@@ -175,7 +175,7 @@ module Autobot
         "Invalid URL"
       end
 
-      private def resolve_and_validate_ip(host : String) : String
+      private def resolve_and_validate_ip(host : String) : Array(String)
         # First check if host looks like an IP address with alternate notation
         if error = check_alternate_ip_notation(host)
           raise error
@@ -211,8 +211,7 @@ module Autobot
 
         raise "No valid IPs found" if validated_ips.empty?
 
-        # Return first validated IP to connect to (prevents DNS rebinding)
-        validated_ips.first
+        validated_ips
       rescue ex
         raise "SSRF validation failed: #{ex.message}"
       end
@@ -271,44 +270,61 @@ module Autobot
         raise "Invalid URI: missing host" unless hostname
 
         # Validate all resolved IPs before connecting (SSRF protection)
-        validated_ip = resolve_and_validate_ip(hostname)
+        validated_ips = resolve_and_validate_ip(hostname)
 
         headers = HTTP::Headers{"User-Agent" => USER_AGENT}
 
+        response = nil
         if uri.scheme == "https"
           # HTTPS: connect via hostname for proper SNI/cert validation.
           # DNS rebinding is mitigated by TLS — a rebind target won't have
           # a valid certificate for the original hostname.
           client = HTTP::Client.new(hostname, uri.port, tls: true)
+          client.read_timeout = DEFAULT_TIMEOUT
+          client.connect_timeout = DEFAULT_TIMEOUT
+          begin
+            response = client.get(uri.request_target, headers: headers)
+          ensure
+            client.close
+          end
         else
           # HTTP: connect to validated IP to prevent DNS rebinding.
-          headers["Host"] = hostname
-          client = HTTP::Client.new(validated_ip, uri.port)
-        end
-        client.read_timeout = DEFAULT_TIMEOUT
-        client.connect_timeout = DEFAULT_TIMEOUT
-
-        begin
-          response = client.get(uri.request_target, headers: headers)
-
-          if response.status.redirection? && (location = response.headers["Location"]?)
-            new_uri = URI.parse(location)
-            # Handle relative redirects
-            unless new_uri.host
-              new_uri = uri.resolve(new_uri)
+          last_exception = nil
+          validated_ips.each do |ip|
+            headers["Host"] = hostname
+            client = HTTP::Client.new(ip, uri.port)
+            client.read_timeout = DEFAULT_TIMEOUT
+            client.connect_timeout = DEFAULT_TIMEOUT
+            begin
+              response = client.get(uri.request_target, headers: headers)
+              break
+            rescue ex : Socket::Error | IO::TimeoutError
+              last_exception = ex
+            ensure
+              client.close
             end
-
-            if error = validate_redirect_uri(new_uri)
-              raise "Redirect blocked: #{error}"
-            end
-
-            return fetch_with_redirects(new_uri, redirects + 1)
           end
 
-          response
-        ensure
-          client.close
+          if response.nil?
+            raise last_exception || Socket::ConnectError.new("Failed to connect to any resolved IP address")
+          end
         end
+
+        if response.status.redirection? && (location = response.headers["Location"]?)
+          new_uri = URI.parse(location)
+          # Handle relative redirects
+          unless new_uri.host
+            new_uri = uri.resolve(new_uri)
+          end
+
+          if error = validate_redirect_uri(new_uri)
+            raise "Redirect blocked: #{error}"
+          end
+
+          return fetch_with_redirects(new_uri, redirects + 1)
+        end
+
+        response
       end
 
       private def validate_redirect_uri(uri : URI) : String?

--- a/src/autobot/tools/web.cr
+++ b/src/autobot/tools/web.cr
@@ -272,43 +272,7 @@ module Autobot
         # Validate all resolved IPs before connecting (SSRF protection)
         validated_ips = resolve_and_validate_ip(hostname)
 
-        headers = HTTP::Headers{"User-Agent" => USER_AGENT}
-
-        response = nil
-        if uri.scheme == "https"
-          # HTTPS: connect via hostname for proper SNI/cert validation.
-          # DNS rebinding is mitigated by TLS — a rebind target won't have
-          # a valid certificate for the original hostname.
-          client = HTTP::Client.new(hostname, uri.port, tls: true)
-          client.read_timeout = DEFAULT_TIMEOUT
-          client.connect_timeout = DEFAULT_TIMEOUT
-          begin
-            response = client.get(uri.request_target, headers: headers)
-          ensure
-            client.close
-          end
-        else
-          # HTTP: connect to validated IP to prevent DNS rebinding.
-          last_exception = nil
-          validated_ips.each do |ip|
-            headers["Host"] = hostname
-            client = HTTP::Client.new(ip, uri.port)
-            client.read_timeout = DEFAULT_TIMEOUT
-            client.connect_timeout = DEFAULT_TIMEOUT
-            begin
-              response = client.get(uri.request_target, headers: headers)
-              break
-            rescue ex : Socket::Error | IO::TimeoutError
-              last_exception = ex
-            ensure
-              client.close
-            end
-          end
-
-          if response.nil?
-            raise last_exception || Socket::ConnectError.new("Failed to connect to any resolved IP address")
-          end
-        end
+        response = fetch_response(uri, hostname, validated_ips)
 
         if response.status.redirection? && (location = response.headers["Location"]?)
           new_uri = URI.parse(location)
@@ -325,6 +289,43 @@ module Autobot
         end
 
         response
+      end
+
+      private def fetch_response(uri : URI, hostname : String, validated_ips : Array(String)) : HTTP::Client::Response
+        headers = HTTP::Headers{"User-Agent" => USER_AGENT}
+
+        if uri.scheme == "https"
+          # HTTPS: connect via hostname for proper SNI/cert validation.
+          # DNS rebinding is mitigated by TLS — a rebind target won't have
+          # a valid certificate for the original hostname.
+          perform_get(HTTP::Client.new(hostname, uri.port, tls: true), uri, headers)
+        else
+          # HTTP: connect to validated IPs instead of the hostname to prevent
+          # DNS rebinding, trying each in order so an unreachable IP falls back
+          # to the next.
+          headers["Host"] = hostname
+          get_first_reachable(validated_ips, uri, headers)
+        end
+      end
+
+      private def get_first_reachable(ips : Array(String), uri : URI, headers : HTTP::Headers) : HTTP::Client::Response
+        last_exception = nil
+
+        ips.each do |ip|
+          return perform_get(HTTP::Client.new(ip, uri.port), uri, headers)
+        rescue ex : Socket::Error | IO::TimeoutError
+          last_exception = ex
+        end
+
+        raise last_exception || Socket::ConnectError.new("Failed to connect to any resolved IP address")
+      end
+
+      private def perform_get(client : HTTP::Client, uri : URI, headers : HTTP::Headers) : HTTP::Client::Response
+        client.read_timeout = DEFAULT_TIMEOUT
+        client.connect_timeout = DEFAULT_TIMEOUT
+        client.get(uri.request_target, headers: headers)
+      ensure
+        client.close
       end
 
       private def validate_redirect_uri(uri : URI) : String?


### PR DESCRIPTION
fix(tools): try all resolved IP addresses in WebFetchTool

When fetching HTTP URLs, WebFetchTool resolved the hostname to multiple
IP addresses, but only attempted to connect to the first one. In environments
where the first resolved IP (e.g. IPv6) is unreachable, this caused connection
timeouts.

This commit updates WebFetchTool to loop over all resolved and validated IP
addresses in order, falling back to the next ones if a socket or timeout
error occurs. It also resolves a minor Ameba Lint/NotNil warning in the HTTP
provider specs.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>
