### PR TITLE
security(tools): prevent SSRF bypass via IPv4-mapped IPv6 in WebFetchTool

### DIFF
--- a/src/autobot/tools/web.cr
+++ b/src/autobot/tools/web.cr
@@ -190,19 +190,22 @@ module Autobot
         addrinfo.each do |addr|
           ip_str = addr.ip_address.address
 
-          if private_ip?(ip_str)
+          # Strip IPv4-mapped IPv6 prefix for validation to prevent SSRF bypass
+          validation_ip = ip_str.starts_with?("::ffff:") ? ip_str.sub("::ffff:", "") : ip_str
+
+          if private_ip?(validation_ip)
             raise "Access to private IP addresses is blocked"
           end
 
-          if loopback?(ip_str)
+          if loopback?(validation_ip)
             raise "Access to localhost is blocked"
           end
 
-          if cloud_metadata?(ip_str)
+          if cloud_metadata?(validation_ip)
             raise "Access to cloud metadata endpoints is blocked"
           end
 
-          if link_local?(ip_str)
+          if link_local?(validation_ip)
             raise "Access to link-local addresses is blocked"
           end
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The WebFetchTool's SSRF protection could be bypassed using IPv4-mapped IPv6 addresses (e.g. `http://[::ffff:127.0.0.1]/`). `Socket::Addrinfo.resolve` returns IPv4-mapped IPv6 address strings (`::ffff:127.0.0.1`), which evaded direct IPv4 string checks (like `ip.starts_with?("127.")`).
🎯 **Impact:** Attackers could query internal network endpoints or cloud metadata by wrapping target IPs in the `::ffff:` mapped prefix.
🔧 **Fix:** Stripped the `::ffff:` prefix from resolved IP strings before validating against private, loopback, link-local, and cloud metadata subnets in `src/autobot/tools/web.cr`.
✅ **Verification:** Ran `crystal spec` (974 passing) and `./bin/ameba` (0 failures).