### PR TITLE
fix(channels): prevent pipe deadlock in telegram script execution

### DIFF
--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -45,6 +45,10 @@ class TelegramChannelTest < Autobot::Channels::TelegramChannel
   def test_parse_script_args(args_str : String) : Array(String)
     parse_script_args(args_str)
   end
+
+  def test_execute_script(script_path : String, args : String, chat_id : String) : Nil
+    execute_script(script_path, args, chat_id)
+  end
 end
 
 private def build_channel(
@@ -414,6 +418,20 @@ describe Autobot::Channels::TelegramChannel do
     it "handles empty string" do
       channel = build_channel
       channel.test_parse_script_args("").should eq([] of String)
+    end
+  end
+
+  describe "#execute_script" do
+    it "handles large stderr output concurrent with stdout without deadlocking" do
+      tmp = TestHelper.tmp_dir
+      script_file = tmp / "test_script.sh"
+      File.write(script_file, "#!/bin/sh\necho 'stdout output'\npython3 -c \"import sys; sys.stderr.write('x' * 100000)\"\nexit 1\n")
+      File.chmod(script_file, 0o755)
+
+      channel = build_channel
+      channel.test_execute_script(script_file.to_s, "", "123")
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
     end
   end
 end

--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -49,6 +49,18 @@ class TelegramChannelTest < Autobot::Channels::TelegramChannel
   def test_execute_script(script_path : String, args : String, chat_id : String) : Nil
     execute_script(script_path, args, chat_id)
   end
+
+  getter sent_replies = [] of String
+
+  private def send_reply(chat_id : String, text : String) : Nil
+    sent_replies << text
+  end
+
+  private def start_typing(chat_id : String) : Nil
+  end
+
+  private def stop_typing(chat_id : String) : Nil
+  end
 end
 
 private def build_channel(
@@ -422,14 +434,23 @@ describe Autobot::Channels::TelegramChannel do
   end
 
   describe "#execute_script" do
-    it "handles large stderr output concurrent with stdout without deadlocking" do
+    it "drains large stderr output concurrent with stdout without deadlocking" do
       tmp = TestHelper.tmp_dir
       script_file = tmp / "test_script.sh"
-      File.write(script_file, "#!/bin/sh\necho 'stdout output'\npython3 -c \"import sys; sys.stderr.write('x' * 100000)\"\nexit 1\n")
+      File.write(script_file, <<-SCRIPT)
+        #!/bin/sh
+        echo 'stdout output'
+        yes x | head -c 100000 >&2
+        exit 1
+        SCRIPT
       File.chmod(script_file, 0o755)
 
       channel = build_channel
       channel.test_execute_script(script_file.to_s, "", "123")
+
+      channel.sent_replies.size.should eq(1)
+      channel.sent_replies.first.should contain("Script failed (exit 1)")
+      channel.sent_replies.first.should contain("truncated")
     ensure
       FileUtils.rm_rf(tmp) if tmp
     end

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -1107,6 +1107,9 @@ module Autobot::Channels
         if bytes_read > max_size
           buffer.write(chunk[0, Math.max(0, max_size - (bytes_read - n))])
           buffer << "\n... (truncated)"
+          # Drain remaining output until EOF to prevent child process pipe deadlocks
+          while io.read(chunk) > 0
+          end
           break
         end
         buffer.write(chunk[0, n])

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -888,6 +888,9 @@ module Autobot::Channels
       end
     end
 
+    SCRIPT_OUTPUT_LIMIT = 4000
+    READ_CHUNK_SIZE     = 4096
+
     private def execute_script(script_path : String, args : String, chat_id : String) : Nil
       expanded = Path[script_path].expand(home: true).to_s
 
@@ -905,14 +908,11 @@ module Autobot::Channels
         error: Process::Redirect::Pipe,
       )
 
-      # Read stdout and stderr concurrently to prevent pipe deadlocks when one stream fills up
-      output_channel = ::Channel(String).new(1)
+      # stderr must be read concurrently with stdout: a child blocked on a full pipe never exits
       error_channel = ::Channel(String).new(1)
+      spawn { error_channel.send(read_limited_io(process.error, SCRIPT_OUTPUT_LIMIT)) }
 
-      spawn { output_channel.send(read_limited_io(process.output, 4000)) }
-      spawn { error_channel.send(read_limited_io(process.error, 4000)) }
-
-      output = output_channel.receive
+      output = read_limited_io(process.output, SCRIPT_OUTPUT_LIMIT)
       error_output = error_channel.receive
       status = process.wait
 
@@ -1106,14 +1106,14 @@ module Autobot::Channels
     private def read_limited_io(io : IO, max_size : Int32) : String
       buffer = IO::Memory.new
       bytes_read = 0
-      chunk = Bytes.new(4096)
+      chunk = Bytes.new(READ_CHUNK_SIZE)
 
       while (n = io.read(chunk)) > 0
         bytes_read += n
         if bytes_read > max_size
           buffer.write(chunk[0, Math.max(0, max_size - (bytes_read - n))])
           buffer << "\n... (truncated)"
-          # Drain remaining output until EOF to prevent child process pipe deadlocks
+          # drain to EOF so the child never blocks on a full pipe
           while io.read(chunk) > 0
           end
           break

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -905,9 +905,15 @@ module Autobot::Channels
         error: Process::Redirect::Pipe,
       )
 
-      # Read with size limit to prevent DoS (truncate at 4000 chars)
-      output = read_limited_io(process.output, 4000)
-      error_output = read_limited_io(process.error, 4000)
+      # Read stdout and stderr concurrently to prevent pipe deadlocks when one stream fills up
+      output_channel = ::Channel(String).new(1)
+      error_channel = ::Channel(String).new(1)
+
+      spawn { output_channel.send(read_limited_io(process.output, 4000)) }
+      spawn { error_channel.send(read_limited_io(process.error, 4000)) }
+
+      output = output_channel.receive
+      error_output = error_channel.receive
       status = process.wait
 
       result = if status.success?


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** `read_limited_io` in `src/autobot/channels/telegram.cr` exited early with `break` if output exceeded `max_size`. This left the pipe open. If a child process produced more output, it would block indefinitely trying to write to the full pipe while `process.wait` waited for exit, causing a deadlock / DoS.
🎯 **Impact:** Malfunctioning or high-output scripts hung the Telegram bot process indefinitely.
🔧 **Fix:** Updated `read_limited_io` to use a bounded reading loop that continues calling `io.read` and discarding excess data until EOF instead of breaking early. This fully drains the pipe and prevents child deadlocks.
✅ **Verification:** Ran `crystal spec` (974 passing) and `./bin/ameba` (0 failures).