### PR TITLE
fix(cli): flush STDOUT on interactive prompts for immediate feedback

### DIFF
--- a/src/autobot/cli/agent.cr
+++ b/src/autobot/cli/agent.cr
@@ -86,6 +86,7 @@ module Autobot
 
         loop do
           print "\e[1;34mYou:\e[0m "
+          STDOUT.flush
           input = gets
           break unless input
 
@@ -101,10 +102,12 @@ module Autobot
 
           session.add_message("user", command)
           print "Thinking..."
+          STDOUT.flush
 
           response = process_message(config, bus, tool_registry, session, command)
 
           print "\r\e[K"
+          STDOUT.flush
 
           session.add_message("assistant", response)
           session_manager.save(session)

--- a/src/autobot/cli/onboard.cr
+++ b/src/autobot/cli/onboard.cr
@@ -59,6 +59,7 @@ module Autobot
 
         if File.exists?(config_file)
           print "Config already exists at #{config_file}. Overwrite? [y/N] "
+          STDOUT.flush
           answer = gets
           unless answer && answer.strip.downcase == "y"
             puts "Aborted."


### PR DESCRIPTION
💡 **What:** Added `STDOUT.flush` immediately after interactive `print` statements in `src/autobot/cli/agent.cr` and `src/autobot/cli/onboard.cr`.
🎯 **Why:** In Crystal CLI applications, `print` without a trailing newline causes output to sit in the line buffer until the next newline or input blocking operation. Adding `STDOUT.flush` immediately after interactive `print` calls ensures loading indicators ("Thinking...") and input prompts ("You: ") render instantly in the terminal without delay.
🔧 **Fix:** Added `STDOUT.flush` after `print` calls in `agent.cr` and `onboard.cr`.
✅ **Verification:** Ran `crystal spec` (974 passing) and `./bin/ameba` (0 failures).