### PR TITLE
refactor(tools): classify SSRF addresses with Socket::IPAddress

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -77,6 +77,7 @@ Built-in protection against Server-Side Request Forgery:
 - Link-local addresses (169.254.x, fe80:)
 - Alternate IP notation (octal: 0177.0.0.1, hex: 0x7f.0.0.1)
 - IPv6 private ranges (fc00::/7, fd00::/8)
+- IPv4-mapped IPv6 (::ffff:127.0.0.1) — unwrapped to the embedded IPv4 before checking
 
 **All DNS records validated** to prevent DNS rebinding attacks.
 

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -74,9 +74,10 @@ The Brave API key can also be set via the `BRAVE_API_KEY` environment variable. 
 4. **Blocks loopback** — `127.x`, `::1`, `0.0.0.0`
 5. **Blocks cloud metadata** — `169.254.169.254` (AWS/GCP/Azure metadata endpoint)
 6. **Blocks link-local** — `169.254.x`, `fe80:`
-7. **Blocks alternate IP notation** — octal (`0177.0.0.1`), hex (`0x7f000001`), integer notation
-8. **Validates redirect targets** — each redirect hop is re-validated against all SSRF checks
-9. **Connects to validated IP** — prevents DNS rebinding by connecting to the resolved IP directly
+7. **Unwraps IPv4-mapped IPv6** — `::ffff:127.0.0.1` is checked as `127.0.0.1`, so mapped addresses cannot bypass the rules above
+8. **Blocks alternate IP notation** — octal (`0177.0.0.1`), hex (`0x7f000001`), integer notation
+9. **Validates redirect targets** — each redirect hop is re-validated against all SSRF checks
+10. **Connects to validated IP** — prevents DNS rebinding by connecting to the resolved IP directly
 
 ### Rate Limiting
 

--- a/spec/autobot/tools/blocked_address_spec.cr
+++ b/spec/autobot/tools/blocked_address_spec.cr
@@ -1,0 +1,80 @@
+require "../../spec_helper"
+require "../../../src/autobot/tools/blocked_address"
+
+private LOCALHOST      = Autobot::Tools::BlockedAddress::LOCALHOST_REASON
+private PRIVATE_RANGE  = Autobot::Tools::BlockedAddress::PRIVATE_REASON
+private CLOUD_METADATA = Autobot::Tools::BlockedAddress::CLOUD_METADATA_REASON
+private LINK_LOCAL     = Autobot::Tools::BlockedAddress::LINK_LOCAL_REASON
+private UNRECOGNIZED   = Autobot::Tools::BlockedAddress::UNRECOGNIZED_REASON
+
+private def reason_for(ip : String) : String?
+  Autobot::Tools::BlockedAddress.reason_for(ip)
+end
+
+describe Autobot::Tools::BlockedAddress do
+  describe ".reason_for" do
+    it "blocks loopback addresses in every notation" do
+      %w[127.0.0.1 127.1.2.3 ::1 ::ffff:127.0.0.1].each do |ip|
+        reason_for(ip).should eq(LOCALHOST)
+      end
+    end
+
+    it "blocks unspecified addresses" do
+      %w[0.0.0.0 ::].each do |ip|
+        reason_for(ip).should eq(LOCALHOST)
+      end
+    end
+
+    it "blocks RFC 1918 and unique local ranges" do
+      %w[10.0.0.1 192.168.1.1 172.16.0.1 172.31.255.255 fc00::1 fd12:3456::1].each do |ip|
+        reason_for(ip).should eq(PRIVATE_RANGE)
+      end
+    end
+
+    it "blocks private ranges wrapped as IPv4-mapped IPv6" do
+      %w[::ffff:10.0.0.1 ::ffff:192.168.1.1 ::ffff:172.16.0.1].each do |ip|
+        reason_for(ip).should eq(PRIVATE_RANGE)
+      end
+    end
+
+    it "blocks link-local ranges" do
+      %w[169.254.1.1 fe80::1 ::ffff:169.254.1.1].each do |ip|
+        reason_for(ip).should eq(LINK_LOCAL)
+      end
+    end
+
+    it "blocks the whole fe80::/10 range, not just the fe80: prefix" do
+      %w[fe90::1 febf::1].each do |ip|
+        reason_for(ip).should eq(LINK_LOCAL)
+      end
+    end
+
+    it "blocks cloud metadata endpoints ahead of their enclosing ranges" do
+      %w[169.254.169.254 fd00:ec2::254 ::ffff:169.254.169.254].each do |ip|
+        reason_for(ip).should eq(CLOUD_METADATA)
+      end
+    end
+
+    it "blocks mapped addresses regardless of prefix casing" do
+      reason_for("::FFFF:10.0.0.1").should eq(PRIVATE_RANGE)
+    end
+
+    it "blocks addresses it cannot parse" do
+      %w[not-an-ip 999.999.999.999].each do |ip|
+        reason_for(ip).should eq(UNRECOGNIZED)
+      end
+    end
+
+    it "allows public addresses" do
+      %w[8.8.8.8 1.1.1.1 2001:4860:4860::8888 ::ffff:8.8.8.8].each do |ip|
+        reason_for(ip).should be_nil
+      end
+    end
+
+    it "allows addresses just outside the 172.16.0.0/12 range" do
+      %w[172.15.0.1 172.32.0.1].each do |ip|
+        reason_for(ip).should be_nil
+      end
+    end
+  end
+end

--- a/src/autobot/tools/blocked_address.cr
+++ b/src/autobot/tools/blocked_address.cr
@@ -1,0 +1,42 @@
+require "socket"
+
+module Autobot
+  module Tools
+    # Classifies IP addresses against ranges that must not be reachable through user-supplied URLs.
+    module BlockedAddress
+      IPV4_MAPPED_PREFIX = "::ffff:"
+
+      CLOUD_METADATA_ADDRESSES = {"169.254.169.254", "fd00:ec2::254"}
+
+      LOCALHOST_REASON      = "Access to localhost is blocked"
+      PRIVATE_REASON        = "Access to private IP addresses is blocked"
+      CLOUD_METADATA_REASON = "Access to cloud metadata endpoints is blocked"
+      LINK_LOCAL_REASON     = "Access to link-local addresses is blocked"
+      UNRECOGNIZED_REASON   = "Access to unrecognized addresses is blocked"
+
+      def self.reason_for(ip : String) : String?
+        address = parse(ip)
+        return UNRECOGNIZED_REASON unless address
+
+        # Metadata endpoints sit inside the link-local and private ranges.
+        return CLOUD_METADATA_REASON if CLOUD_METADATA_ADDRESSES.includes?(address.address)
+        return LOCALHOST_REASON if address.loopback? || address.unspecified?
+        return PRIVATE_REASON if address.private?
+        return LINK_LOCAL_REASON if address.link_local?
+
+        nil
+      end
+
+      # Socket::IPAddress unwraps IPv4-mapped IPv6 for #loopback? only, so the embedded IPv4 is classified directly.
+      private def self.parse(ip : String) : Socket::IPAddress?
+        build(ip.downcase.lchop?(IPV4_MAPPED_PREFIX)) || build(ip)
+      end
+
+      private def self.build(ip : String?) : Socket::IPAddress?
+        ip ? Socket::IPAddress.new(ip, 0) : nil
+      rescue Socket::Error
+        nil
+      end
+    end
+  end
+end

--- a/src/autobot/tools/web.cr
+++ b/src/autobot/tools/web.cr
@@ -2,6 +2,7 @@ require "http/client"
 require "json"
 require "log"
 require "uri"
+require "./blocked_address"
 require "./result"
 
 module Autobot
@@ -190,23 +191,8 @@ module Autobot
         addrinfo.each do |addr|
           ip_str = addr.ip_address.address
 
-          # Strip IPv4-mapped IPv6 prefix for validation to prevent SSRF bypass
-          validation_ip = ip_str.starts_with?("::ffff:") ? ip_str.sub("::ffff:", "") : ip_str
-
-          if private_ip?(validation_ip)
-            raise "Access to private IP addresses is blocked"
-          end
-
-          if loopback?(validation_ip)
-            raise "Access to localhost is blocked"
-          end
-
-          if cloud_metadata?(validation_ip)
-            raise "Access to cloud metadata endpoints is blocked"
-          end
-
-          if link_local?(validation_ip)
-            raise "Access to link-local addresses is blocked"
+          if reason = BlockedAddress.reason_for(ip_str)
+            raise reason
           end
 
           validated_ips << ip_str
@@ -237,31 +223,6 @@ module Autobot
         end
 
         nil
-      end
-
-      private def private_ip?(ip : String) : Bool
-        # IPv4 RFC 1918 private ranges
-        return true if ip.starts_with?("10.")                       # 10.0.0.0/8
-        return true if ip.starts_with?("192.168.")                  # 192.168.0.0/16
-        return true if ip.matches?(/^172\.(1[6-9]|2[0-9]|3[01])\./) # 172.16.0.0/12
-
-        # IPv6 private ranges
-        return true if ip.starts_with?("fc") # fc00::/7 (Unique Local)
-        return true if ip.starts_with?("fd") # fd00::/8 (Unique Local)
-
-        false
-      end
-
-      private def loopback?(ip : String) : Bool
-        ip.starts_with?("127.") || ip == "::1" || ip == "0.0.0.0" || ip == "::"
-      end
-
-      private def cloud_metadata?(ip : String) : Bool
-        ip == "169.254.169.254" || ip == "fd00:ec2::254"
-      end
-
-      private def link_local?(ip : String) : Bool
-        ip.starts_with?("169.254.") || ip.starts_with?("fe80:")
       end
 
       private def fetch_with_redirects(uri : URI, redirects = 0) : HTTP::Client::Response


### PR DESCRIPTION
## What

Replaces the hand-rolled string-prefix IP checks in `WebFetchTool` with a dedicated `BlockedAddress` module backed by `Socket::IPAddress` predicates.

The four private predicates (`private_ip?`, `loopback?`, `cloud_metadata?`, `link_local?`) matched on string prefixes like `"127."` and `"fe80:"`. That approach is what allowed the IPv4-mapped IPv6 bypass fixed in #84, and it is fragile for any address form that does not match the expected text shape.

## The catch

`Socket::IPAddress` unwraps IPv4-mapped IPv6 for `#loopback?` **only**. `#private?` and `#link_local?` do not:

| address | `loopback?` | `private?` | `link_local?` |
|---|---|---|---|
| `::ffff:127.0.0.1` | true | false | false |
| `::ffff:10.0.0.1` | false | **false** | false |
| `::ffff:169.254.169.254` | false | false | **false** |

So swapping in the stdlib predicates naively would have **reopened #84** for the private and cloud-metadata ranges. `BlockedAddress` resolves the mapped form to its embedded IPv4 before classifying, which is the load-bearing part of the change.

Cloud-metadata is checked first because `fd00:ec2::254` is also `private?`, which would otherwise swallow the specific error message.

## Extra fix

The old `starts_with?("fe80:")` check covered only part of `fe80::/10`. Addresses like `fe90::1` and `febf::1` are link-local but were **allowed**. The stdlib predicate covers the full range.

## Verification

- Differential test over a 296-address corpus comparing old vs new: **zero regressions** (nothing the old code blocked is now allowed), with `fe90::1` / `febf::1` newly blocked.
- New `spec/autobot/tools/blocked_address_spec.cr` covers every category across plain IPv4, plain IPv6, and `::ffff:`-mapped forms, plus `172.16.0.0/12` boundaries and uppercase `::FFFF:` prefixes.
- `crystal spec` — 985 examples, 0 failures
- `./bin/ameba` — 139 inspected, 0 failures
- `make release` — succeeds

## Out of scope

`check_alternate_ip_notation` (octal/hex/integer) is left as-is. Worth noting for a follow-up: the resolver already normalizes `0x7f000001`, `2130706433`, and `127.1` to `127.0.0.1`, so post-resolution validation catches those regardless — the regexes are defense-in-depth rather than the primary control.