### PR TITLE
fix(agent): synchronize SubagentManager running tasks for multithreading safety

### DIFF
--- a/spec/autobot/agent/subagent_spec.cr
+++ b/spec/autobot/agent/subagent_spec.cr
@@ -23,6 +23,15 @@ private class BlockingSubagentManager < Autobot::Agent::SubagentManager
   ) : Nil
     @started.send(nil)
     @gate.receive
+  end
+
+  private def run_and_untrack(
+    task_id : String,
+    task : String,
+    label : String,
+    origin : Hash(String, String),
+  ) : Nil
+    super
   ensure
     @completed.send(nil)
   end
@@ -38,6 +47,15 @@ private class FailingSubagentManager < Autobot::Agent::SubagentManager
     origin : Hash(String, String),
   ) : Nil
     raise "Simulated background subagent failure"
+  end
+
+  private def run_and_untrack(
+    task_id : String,
+    task : String,
+    label : String,
+    origin : Hash(String, String),
+  ) : Nil
+    super
   ensure
     @completed.send(nil)
   end
@@ -46,7 +64,7 @@ end
 private class TrackingSubagentManager < Autobot::Agent::SubagentManager
   getter completed = Channel(String).new(100)
 
-  private def run_subagent(
+  private def run_and_untrack(
     task_id : String,
     task : String,
     label : String,
@@ -81,12 +99,6 @@ describe Autobot::Agent::SubagentManager do
     manager.gate.send(nil)
     manager.completed.receive
 
-    # Wait for outer ensure block to cleanly delete task
-    100.times do
-      break if manager.running_count == 0
-      sleep 1.millisecond
-    end
-
     manager.running_count.should eq(0)
   ensure
     FileUtils.rm_rf(tmp) if tmp
@@ -106,14 +118,8 @@ describe Autobot::Agent::SubagentManager do
     manager.running_count.should eq(0)
     manager.spawn("Failing task", label: "Failing Worker")
 
-    # Wait until background fiber finishes and raises
+    # Wait until background fiber finishes and cleans up
     manager.completed.receive
-
-    # Wait for outer ensure block to cleanly delete task
-    100.times do
-      break if manager.running_count == 0
-      sleep 1.millisecond
-    end
 
     manager.running_count.should eq(0)
   ensure
@@ -145,12 +151,6 @@ describe Autobot::Agent::SubagentManager do
 
     # Deterministically wait for all 25 subagent background fibers to complete
     concurrent_tasks.times { manager.completed.receive }
-
-    # Wait for outer ensure block to cleanly delete all tasks
-    100.times do
-      break if manager.running_count == 0
-      sleep 1.millisecond
-    end
 
     manager.running_count.should eq(0)
   ensure

--- a/spec/autobot/agent/subagent_spec.cr
+++ b/spec/autobot/agent/subagent_spec.cr
@@ -1,0 +1,159 @@
+require "../../spec_helper"
+
+private class MockSubagentProvider < Autobot::Providers::HttpProvider
+  def initialize
+    super(api_key: "test-key", model: "mock-model")
+  end
+
+  private def http_post(url : String, headers : HTTP::Headers, body : String) : HTTP::Client::Response
+    HTTP::Client::Response.new(200, body: %({"choices":[{"message":{"content":"Subagent finished"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}))
+  end
+end
+
+private class BlockingSubagentManager < Autobot::Agent::SubagentManager
+  getter started = Channel(Nil).new
+  getter gate = Channel(Nil).new
+  getter completed = Channel(Nil).new
+
+  private def run_subagent(
+    task_id : String,
+    task : String,
+    label : String,
+    origin : Hash(String, String),
+  ) : Nil
+    @started.send(nil)
+    @gate.receive
+  ensure
+    @completed.send(nil)
+  end
+end
+
+private class FailingSubagentManager < Autobot::Agent::SubagentManager
+  getter completed = Channel(Nil).new
+
+  private def run_subagent(
+    task_id : String,
+    task : String,
+    label : String,
+    origin : Hash(String, String),
+  ) : Nil
+    raise "Simulated background subagent failure"
+  ensure
+    @completed.send(nil)
+  end
+end
+
+private class TrackingSubagentManager < Autobot::Agent::SubagentManager
+  getter completed = Channel(String).new(100)
+
+  private def run_subagent(
+    task_id : String,
+    task : String,
+    label : String,
+    origin : Hash(String, String),
+  ) : Nil
+    super
+  ensure
+    @completed.send(task_id)
+  end
+end
+
+describe Autobot::Agent::SubagentManager do
+  it "tracks running task count while subagent is running and cleans up on completion" do
+    tmp = TestHelper.tmp_dir
+    bus = Autobot::Bus::MessageBus.new(capacity: 10)
+    provider = MockSubagentProvider.new
+    manager = BlockingSubagentManager.new(
+      provider: provider,
+      workspace: tmp,
+      bus: bus,
+      sandbox_config: "none",
+    )
+
+    manager.running_count.should eq(0)
+    manager.spawn("Do work", label: "Worker 1")
+
+    # Wait until background fiber begins executing
+    manager.started.receive
+    manager.running_count.should eq(1)
+
+    # Release gate and wait for fiber completion
+    manager.gate.send(nil)
+    manager.completed.receive
+
+    # Wait for outer ensure block to cleanly delete task
+    100.times do
+      break if manager.running_count == 0
+      sleep 1.millisecond
+    end
+
+    manager.running_count.should eq(0)
+  ensure
+    FileUtils.rm_rf(tmp) if tmp
+  end
+
+  it "guarantees running task cleanup even if subagent fiber raises an error" do
+    tmp = TestHelper.tmp_dir
+    bus = Autobot::Bus::MessageBus.new(capacity: 10)
+    provider = MockSubagentProvider.new
+    manager = FailingSubagentManager.new(
+      provider: provider,
+      workspace: tmp,
+      bus: bus,
+      sandbox_config: "none",
+    )
+
+    manager.running_count.should eq(0)
+    manager.spawn("Failing task", label: "Failing Worker")
+
+    # Wait until background fiber finishes and raises
+    manager.completed.receive
+
+    # Wait for outer ensure block to cleanly delete task
+    100.times do
+      break if manager.running_count == 0
+      sleep 1.millisecond
+    end
+
+    manager.running_count.should eq(0)
+  ensure
+    FileUtils.rm_rf(tmp) if tmp
+  end
+
+  it "handles concurrent spawn and completion across multiple fibers safely" do
+    tmp = TestHelper.tmp_dir
+    bus = Autobot::Bus::MessageBus.new(capacity: 100)
+    provider = MockSubagentProvider.new
+    manager = TrackingSubagentManager.new(
+      provider: provider,
+      workspace: tmp,
+      bus: bus,
+      sandbox_config: "none",
+    )
+
+    concurrent_tasks = 25
+    spawn_done = Channel(Nil).new
+
+    concurrent_tasks.times do |i|
+      spawn do
+        manager.spawn("Task #{i}", label: "T#{i}")
+        spawn_done.send(nil)
+      end
+    end
+
+    concurrent_tasks.times { spawn_done.receive }
+
+    # Deterministically wait for all 25 subagent background fibers to complete
+    concurrent_tasks.times { manager.completed.receive }
+
+    # Wait for outer ensure block to cleanly delete all tasks
+    100.times do
+      break if manager.running_count == 0
+      sleep 1.millisecond
+    end
+
+    manager.running_count.should eq(0)
+  ensure
+    FileUtils.rm_rf(tmp) if tmp
+  end
+end

--- a/src/autobot/agent/subagent.cr
+++ b/src/autobot/agent/subagent.cr
@@ -42,6 +42,7 @@ module Autobot
       @sandbox_config : String
       @rate_limiter : Tools::RateLimiter?
       @running_tasks : Hash(String, Bool) = {} of String => Bool
+      @tasks_mutex : Mutex = Mutex.new
 
       def initialize(
         @provider : Providers::Provider,
@@ -70,11 +71,18 @@ module Autobot
 
         origin = {"channel" => origin_channel, "chat_id" => origin_chat_id}
 
-        @running_tasks[task_id] = true
+        @tasks_mutex.synchronize do
+          @running_tasks[task_id] = true
+        end
 
         ::spawn do
-          run_subagent(task_id, task, display_label, origin)
-          @running_tasks.delete(task_id)
+          begin
+            run_subagent(task_id, task, display_label, origin)
+          ensure
+            @tasks_mutex.synchronize do
+              @running_tasks.delete(task_id)
+            end
+          end
         end
 
         Log.info { "Spawned subagent [#{task_id}]: #{display_label}" }
@@ -83,7 +91,9 @@ module Autobot
 
       # Return the number of currently running subagents.
       def running_count : Int32
-        @running_tasks.size
+        @tasks_mutex.synchronize do
+          @running_tasks.size
+        end
       end
 
       private def run_subagent(

--- a/src/autobot/agent/subagent.cr
+++ b/src/autobot/agent/subagent.cr
@@ -76,13 +76,7 @@ module Autobot
         end
 
         ::spawn do
-          begin
-            run_subagent(task_id, task, display_label, origin)
-          ensure
-            @tasks_mutex.synchronize do
-              @running_tasks.delete(task_id)
-            end
-          end
+          run_and_untrack(task_id, task, display_label, origin)
         end
 
         Log.info { "Spawned subagent [#{task_id}]: #{display_label}" }
@@ -93,6 +87,19 @@ module Autobot
       def running_count : Int32
         @tasks_mutex.synchronize do
           @running_tasks.size
+        end
+      end
+
+      private def run_and_untrack(
+        task_id : String,
+        task : String,
+        label : String,
+        origin : Hash(String, String),
+      ) : Nil
+        run_subagent(task_id, task, label, origin)
+      ensure
+        @tasks_mutex.synchronize do
+          @running_tasks.delete(task_id)
         end
       end
 


### PR DESCRIPTION
## Description
In `SubagentManager` (`src/autobot/agent/subagent.cr`), `@running_tasks : Hash(String, Bool)` tracks active background subagents.

Previously:
1. Writes (`spawn`), deletions (`::spawn`), and reads (`running_count`) on `@running_tasks` were executed concurrently without synchronization, leading to data races under multithreaded runtime (`-Dpreview_mt`).
2. `@running_tasks.delete(task_id)` was placed sequentially after `run_subagent` without an `ensure` block. If `run_subagent` encountered an unhandled error, the task entry was never deleted and leaked a permanent zombie task count in `running_count`.

## Changes
- Introduced `@tasks_mutex : Mutex = Mutex.new` to synchronize all writes, deletions, and reads on `@running_tasks`.
- Wrapped subagent execution in `begin ... ensure @tasks_mutex.synchronize { @running_tasks.delete(task_id) } end` to guarantee task cleanup on unhandled exceptions.
- Added comprehensive unit specs in `spec/autobot/agent/subagent_spec.cr` testing active task tracking, exception cleanup, and concurrent fiber execution.

Closes #97.
Part of #92.