### PR TITLE
fix(http): close raw TCPSocket when proxy CONNECT or TLS handshake fails

### DIFF
--- a/spec/autobot/http_spec.cr
+++ b/spec/autobot/http_spec.cr
@@ -69,11 +69,12 @@ describe Autobot::HTTP do
       port = server.local_address.port
 
       spawn do
-        if socket = server.accept?
+        while socket = server.accept?
           socket.close
         end
       end
 
+      open_fds = Dir.children("/dev/fd").size
       proxy_client = HTTP::Proxy::Client.new("127.0.0.1", port)
       tls_ctx = OpenSSL::SSL::Context::Client.new
 
@@ -88,6 +89,7 @@ describe Autobot::HTTP do
           write_timeout: 2.seconds
         )
       end
+      Dir.children("/dev/fd").size.should eq(open_fds)
     ensure
       server.close if server
     end
@@ -97,7 +99,7 @@ describe Autobot::HTTP do
       port = server.local_address.port
 
       spawn do
-        if socket = server.accept?
+        while socket = server.accept?
           while (line = socket.gets) && !line.empty?
           end
           socket << "HTTP/1.1 200 Connection established\r\n\r\n"
@@ -108,6 +110,7 @@ describe Autobot::HTTP do
         end
       end
 
+      open_fds = Dir.children("/dev/fd").size
       proxy_client = HTTP::Proxy::Client.new("127.0.0.1", port)
       tls_ctx = OpenSSL::SSL::Context::Client.new
 
@@ -122,6 +125,7 @@ describe Autobot::HTTP do
           write_timeout: 2.seconds
         )
       end
+      Dir.children("/dev/fd").size.should eq(open_fds)
     ensure
       server.close if server
     end

--- a/spec/autobot/http_spec.cr
+++ b/spec/autobot/http_spec.cr
@@ -114,7 +114,7 @@ describe Autobot::HTTP do
       proxy_client = HTTP::Proxy::Client.new("127.0.0.1", port)
       tls_ctx = OpenSSL::SSL::Context::Client.new
 
-      expect_raises(Exception) do
+      expect_raises(OpenSSL::SSL::Error) do
         proxy_client.open(
           "api.telegram.org",
           443,
@@ -125,6 +125,38 @@ describe Autobot::HTTP do
           write_timeout: 2.seconds
         )
       end
+      Dir.children("/dev/fd").size.should eq(open_fds)
+    ensure
+      server.close if server
+    end
+
+    it "releases the socket when the proxied TLS handshake fails via Autobot::HTTP.with_client" do
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.local_address.port
+
+      spawn do
+        while socket = server.accept?
+          while (line = socket.gets) && !line.empty?
+          end
+          socket << "HTTP/1.1 200 Connection established\r\n\r\n"
+          socket.flush
+          socket.write("invalid tls handshake".to_slice)
+          socket.flush
+          socket.close
+        end
+      end
+
+      attempt = -> do
+        expect_raises(OpenSSL::SSL::Error) do
+          Autobot::HTTP.with_client("https://api.telegram.org", proxy: "http://127.0.0.1:#{port}") do |client|
+            client.get("/")
+          end
+        end
+      end
+
+      attempt.call
+      open_fds = Dir.children("/dev/fd").size
+      attempt.call
       Dir.children("/dev/fd").size.should eq(open_fds)
     ensure
       server.close if server

--- a/spec/autobot/http_spec.cr
+++ b/spec/autobot/http_spec.cr
@@ -62,4 +62,68 @@ describe Autobot::HTTP do
       end
     end
   end
+
+  describe "HTTP::Proxy::Client#open socket safety" do
+    it "closes underlying socket when CONNECT handshake fails" do
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.local_address.port
+
+      spawn do
+        if socket = server.accept?
+          socket.close
+        end
+      end
+
+      proxy_client = HTTP::Proxy::Client.new("127.0.0.1", port)
+      tls_ctx = OpenSSL::SSL::Context::Client.new
+
+      expect_raises(Exception) do
+        proxy_client.open(
+          "api.telegram.org",
+          443,
+          tls: tls_ctx,
+          dns_timeout: 2.seconds,
+          connect_timeout: 2.seconds,
+          read_timeout: 2.seconds,
+          write_timeout: 2.seconds
+        )
+      end
+    ensure
+      server.close if server
+    end
+
+    it "closes underlying socket when TLS negotiation fails" do
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.local_address.port
+
+      spawn do
+        if socket = server.accept?
+          while (line = socket.gets) && !line.empty?
+          end
+          socket << "HTTP/1.1 200 Connection established\r\n\r\n"
+          socket.flush
+          socket.write("invalid tls handshake".to_slice)
+          socket.flush
+          socket.close
+        end
+      end
+
+      proxy_client = HTTP::Proxy::Client.new("127.0.0.1", port)
+      tls_ctx = OpenSSL::SSL::Context::Client.new
+
+      expect_raises(Exception) do
+        proxy_client.open(
+          "api.telegram.org",
+          443,
+          tls: tls_ctx,
+          dns_timeout: 2.seconds,
+          connect_timeout: 2.seconds,
+          read_timeout: 2.seconds,
+          write_timeout: 2.seconds
+        )
+      end
+    ensure
+      server.close if server
+    end
+  end
 end

--- a/src/autobot/http.cr
+++ b/src/autobot/http.cr
@@ -2,6 +2,54 @@ require "http/client"
 require "http_proxy"
 require "uri"
 
+# Patch HTTP::Proxy::Client#open to close raw TCPSocket if TLS negotiation or CONNECT fails.
+class HTTP::Proxy::Client
+  def open(host, port, tls = nil, *, dns_timeout, connect_timeout, read_timeout, write_timeout) : IO
+    socket = TCPSocket.new(@host, @port, dns_timeout, connect_timeout)
+    socket.read_timeout = read_timeout if read_timeout
+    socket.write_timeout = write_timeout if write_timeout
+    socket.sync = false
+
+    if tls
+      begin
+        socket << "CONNECT #{host}:#{port} HTTP/1.1\r\n"
+
+        @headers.each do |name, values|
+          values.each do |value|
+            socket << "#{name}: #{value}\r\n"
+          end
+        end
+
+        socket << "Host: #{host}:#{port}\r\n"
+
+        if (username = @username) && (password = @password)
+          credentials = Base64.strict_encode("#{username}:#{password}")
+          socket << "Proxy-Authorization: Basic #{credentials}\r\n"
+        end
+
+        socket << "\r\n"
+        socket.flush
+
+        resp = HTTP::Client::Response.from_io(socket, ignore_body: true)
+
+        if resp.success?
+          {% if !flag?(:without_openssl) %}
+            socket = OpenSSL::SSL::Socket::Client.new(socket, context: tls, sync_close: true, hostname: host)
+          {% end %}
+        else
+          socket.close rescue nil
+          raise IO::Error.new("Proxy CONNECT failed: #{resp.status_code}")
+        end
+      rescue ex
+        socket.close rescue nil
+        raise ex
+      end
+    end
+
+    socket
+  end
+end
+
 module Autobot
   # Centralized HTTP utility for managing HTTP::Client instances, timeouts,
   # proxy routing, and deterministic exception-safe socket closure.

--- a/src/autobot/http.cr
+++ b/src/autobot/http.cr
@@ -22,8 +22,8 @@ class HTTP::Proxy::Client
 
         socket << "Host: #{host}:#{port}\r\n"
 
-        if (username = @username) && (password = @password)
-          credentials = Base64.strict_encode("#{username}:#{password}")
+        if @username
+          credentials = Base64.strict_encode("#{@username}:#{@password}")
           socket << "Proxy-Authorization: Basic #{credentials}\r\n"
         end
 


### PR DESCRIPTION
## Summary

This PR implements the second part (PR B) of the HTTP proxy socket safety refactoring as suggested by @veelenga in #93.

### Root Cause
In `http_proxy`, `HTTP::Proxy::Client#open` creates a raw `TCPSocket` and issues a `CONNECT` request for TLS tunneling. If either the proxy `CONNECT` handshake fails or subsequent TLS negotiation raises an exception (`OpenSSL::SSL::Error`), the raw `TCPSocket` is left open, leaking file descriptors.

### Changes
1. **Exact Signature Override**: Overrides `HTTP::Proxy::Client#open` with the exact required named argument signature matching the shard (`def open(host, port, tls = nil, *, dns_timeout, connect_timeout, read_timeout, write_timeout) : IO`) to ensure accurate method dispatch.
2. **Deterministic Exception Cleanup**: Wraps the `CONNECT` request and TLS handshake in `begin ... rescue ex; socket.close rescue nil; raise ex; end` ensuring raw sockets are closed when errors occur.
3. **Deterministic Specs**: Added tests in `spec/autobot/http_spec.cr` verifying that the underlying socket is closed on failed `CONNECT` responses and on failed TLS negotiation.

Ref: #93

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>