### PR TITLE
chore: bump version to v0.7.2

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: autobot
-version: 0.7.0
+version: 0.7.2
 
 authors:
   - Vitalii Elenhaupt


### PR DESCRIPTION
## Overview

- [x] bump shard.yml version to 0.7.2