### PR TITLE
fix(agent): propagate max_tokens and prevent empty response delivery

### DIFF
--- a/spec/autobot/agent/loop_spec.cr
+++ b/spec/autobot/agent/loop_spec.cr
@@ -2,12 +2,19 @@ require "../../spec_helper"
 
 # Mock provider that returns a simple text response (no tool calls).
 class MockProvider < Autobot::Providers::HttpProvider
-  def initialize
+  def initialize(@response_content : String = "Mock response", @responses : Array(String)? = nil)
     super(api_key: "test-key", model: "mock-model")
+    @response_index = 0
   end
 
   private def http_post(url : String, headers : HTTP::Headers, body : String) : HTTP::Client::Response
-    HTTP::Client::Response.new(200, body: %({"choices":[{"message":{"content":"Mock response"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}))
+    if responses = @responses
+      resp = responses[@response_index]? || responses.last
+      @response_index += 1
+      HTTP::Client::Response.new(200, body: resp)
+    else
+      HTTP::Client::Response.new(200, body: %({"choices":[{"message":{"content":#{@response_content.to_json}},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}))
+    end
   end
 end
 
@@ -308,6 +315,79 @@ describe Autobot::Agent::Loop do
       response.try(&.content).should eq(Autobot::Agent::Loop::VOICE_NOTE_NOT_HEARD)
       response.try(&.metadata["thread_ts"]).should eq("1")
       Autobot::Session::Manager.new(tmp).get_or_create("telegram:chat1").get_history.should be_empty
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
+    it "falls back to FALLBACK_RESPONSE when provider returns empty string" do
+      tmp = TestHelper.tmp_dir
+      bus = Autobot::Bus::MessageBus.new(capacity: 10)
+      provider = MockProvider.new(response_content: "")
+      tools = Autobot::Tools::Registry.new
+      sessions = Autobot::Session::Manager.new(tmp)
+
+      loop_inst = TestableLoop.new(
+        bus: bus,
+        provider: provider,
+        workspace: tmp,
+        tools: tools,
+        sessions: sessions,
+        memory_window: 0,
+        sandbox_config: "none"
+      )
+
+      msg = Autobot::Bus::InboundMessage.new(
+        channel: "telegram",
+        sender_id: "user1",
+        chat_id: "chat1",
+        content: "Hello"
+      )
+
+      response = loop_inst.test_process_message(msg)
+      response.should_not be_nil
+      response.try(&.content).should eq(Autobot::Agent::Loop::FALLBACK_RESPONSE)
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
+    it "saves message tool content to session history when LLM returns empty string" do
+      tmp = TestHelper.tmp_dir
+      sessions = Autobot::Session::Manager.new(tmp)
+      bus = Autobot::Bus::MessageBus.new(capacity: 10)
+      tool_call_resp = %({"choices":[{"message":{"content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"message","arguments":"{\\"content\\":\\"Sent via message tool\\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}})
+      empty_resp = %({"choices":[{"message":{"content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}})
+      provider = MockProvider.new(responses: [tool_call_resp, empty_resp])
+      tools = Autobot::Tools::Registry.new
+
+      message_tool = Autobot::Tools::MessageTool.new
+      tools.register(message_tool)
+
+      loop_inst = TestableLoop.new(
+        bus: bus,
+        provider: provider,
+        workspace: tmp,
+        tools: tools,
+        sessions: sessions,
+        memory_window: 0,
+        sandbox_config: "none"
+      )
+
+      msg = Autobot::Bus::InboundMessage.new(
+        channel: "telegram",
+        sender_id: "user1",
+        chat_id: "chat1",
+        content: "Hello"
+      )
+
+      response = loop_inst.test_process_message(msg)
+      response.should be_nil
+
+      session = sessions.get_or_create("telegram:chat1")
+      history = session.get_history
+      history.size.should eq(2)
+      history[0]["role"].should eq("user")
+      history[1]["role"].should eq("assistant")
+      history[1]["content"].should eq("Sent via message tool")
     ensure
       FileUtils.rm_rf(tmp) if tmp
     end

--- a/spec/autobot/agent/memory_manager_spec.cr
+++ b/spec/autobot/agent/memory_manager_spec.cr
@@ -3,6 +3,7 @@ require "../../spec_helper"
 # Mock provider for memory manager tests.
 class MemoryMockProvider < Autobot::Providers::HttpProvider
   getter call_count : Int32 = 0
+  getter sent_bodies : Array(String) = [] of String
 
   def initialize
     super(api_key: "test-key", model: "mock-model")
@@ -10,6 +11,7 @@ class MemoryMockProvider < Autobot::Providers::HttpProvider
 
   private def http_post(url : String, headers : HTTP::Headers, body : String) : HTTP::Client::Response
     @call_count += 1
+    @sent_bodies << body
     json_response = %({"history_entry":"[2025-01-01] Summary of conversation","memory_update":"User prefers dark mode"})
     HTTP::Client::Response.new(200, body: %({"choices":[{"message":{"content":#{json_response.to_json}},"finish_reason":"stop"}],"usage":{"prompt_tokens":50,"completion_tokens":20,"total_tokens":70}}))
   end
@@ -198,6 +200,32 @@ describe Autobot::Agent::MemoryManager do
       # Should have the trimmed messages plus the new one
       reloaded.messages.size.should eq(4) # 3 kept + 1 new
       reloaded.messages.last.content.should eq("New message after consolidation")
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
+    it "passes configured max_tokens to the summarization request" do
+      tmp = TestHelper.tmp_dir
+      provider = MemoryMockProvider.new
+      sessions = Autobot::Session::Manager.new(tmp)
+
+      manager = Autobot::Agent::MemoryManager.new(
+        workspace: tmp,
+        provider: provider,
+        model: "mock-model",
+        memory_window: 6,
+        sessions: sessions,
+        max_tokens: 32768
+      )
+
+      session = sessions.get_or_create("test:max_tokens")
+      10.times { |i| session.add_message("user", "Message #{i}") }
+
+      manager.consolidate_if_needed(session)
+      sleep(200.milliseconds)
+
+      provider.sent_bodies.size.should eq(1)
+      JSON.parse(provider.sent_bodies.first)["max_tokens"].as_i.should eq(32768)
     ensure
       FileUtils.rm_rf(tmp) if tmp
     end

--- a/spec/autobot/agent/tool_executor_spec.cr
+++ b/spec/autobot/agent/tool_executor_spec.cr
@@ -136,6 +136,30 @@ end
 
 describe Autobot::Agent::ToolExecutor do
   describe "#execute" do
+    it "passes configured max_tokens and temperature to provider" do
+      provider = SequenceMockProvider.new([text_response("Hello, world!")])
+      workspace = TestHelper.tmp_dir("tool_executor_params_test")
+      context = Autobot::Agent::Context::Builder.new(workspace)
+      executor = Autobot::Agent::ToolExecutor.new(
+        provider: provider,
+        context: context,
+        model: "mock-model",
+        max_tokens: 32768,
+        temperature: 0.7
+      )
+      tools = Autobot::Tools::Registry.new
+
+      result = executor.execute(build_messages, tools)
+
+      result.content.should eq("Hello, world!")
+      provider.sent_bodies.size.should eq(1)
+      sent_json = JSON.parse(provider.sent_bodies.first)
+      sent_json["max_tokens"].as_i.should eq(32768)
+      sent_json["temperature"].as_f.should eq(0.7)
+    ensure
+      FileUtils.rm_rf(workspace) if workspace
+    end
+
     it "returns text content when LLM responds without tool calls" do
       provider = SequenceMockProvider.new([text_response("Hello, world!")])
       executor = build_executor(provider)

--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -833,4 +833,18 @@ describe Autobot::Channels::TelegramChannel do
       server.close if server
     end
   end
+
+  describe "#send_message" do
+    it "ignores empty or whitespace-only messages without sending requests" do
+      channel = build_channel
+      outbound = Autobot::Bus::OutboundMessage.new(
+        channel: "telegram",
+        chat_id: "123",
+        content: "   \n  "
+      )
+
+      channel.send_message(outbound)
+      channel.created_clients.should be_empty
+    end
+  end
 end

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -91,7 +91,8 @@ module Autobot::Agent
         provider: @provider,
         model: @model,
         memory_window: @memory_window,
-        sessions: @sessions
+        sessions: @sessions,
+        max_tokens: max_tokens
       )
 
       register_optional_tools(

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -310,8 +310,8 @@ module Autobot::Agent
       enabled_tools : Array(String),
       filesystem_roots : Array(String),
       web_allowed_domains : Array(String),
-      max_tokens : Int32 = Config::AgentDefaults.new.max_tokens,
-      temperature : Float64 = Config::AgentDefaults.new.temperature,
+      max_tokens : Int32,
+      temperature : Float64,
     ) : Nil
       subagents = SubagentManager.new(
         provider: @provider,

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -70,6 +70,8 @@ module Autobot::Agent
       enabled_tools : Array(String) = [] of String,
       filesystem_roots : Array(String) = [] of String,
       web_allowed_domains : Array(String) = [] of String,
+      max_tokens : Int32 = Config::AgentDefaults.new.max_tokens,
+      temperature : Float64 = Config::AgentDefaults.new.temperature,
     )
       @model = model || @provider.default_model
       sandboxed = sandbox_config.downcase != "none"
@@ -79,7 +81,9 @@ module Autobot::Agent
         provider: @provider,
         context: @context,
         model: @model,
-        max_iterations: @max_iterations
+        max_iterations: @max_iterations,
+        max_tokens: max_tokens,
+        temperature: temperature
       )
 
       @memory_manager = MemoryManager.new(
@@ -90,7 +94,11 @@ module Autobot::Agent
         sessions: @sessions
       )
 
-      register_optional_tools(brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns, sandbox_config, rate_limiter, enabled_tools, filesystem_roots, web_allowed_domains)
+      register_optional_tools(
+        brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns,
+        sandbox_config, rate_limiter, enabled_tools, filesystem_roots, web_allowed_domains,
+        max_tokens: max_tokens, temperature: temperature
+      )
       cache_tool_references
     end
 
@@ -175,7 +183,7 @@ module Autobot::Agent
 
       @message_tool.try(&.clear_last_sent)
       result = @executor.execute(messages, @tools, session_key: session.key)
-      final_content = result.content || FALLBACK_RESPONSE
+      final_content = result.content.presence || @message_tool.try(&.last_sent_content) || FALLBACK_RESPONSE
 
       save_to_session(session, @context.render_user_text(msg.content, msg.media?), final_content, result.tools_used)
 
@@ -229,7 +237,7 @@ module Autobot::Agent
 
     # Persist the cron exchange to session so followup messages have context.
     private def save_cron_to_session(session : Session::Session, task_content : String, result : ToolExecutor::Result) : Nil
-      response_content = @message_tool.try(&.last_sent_content) || result.content
+      response_content = @message_tool.try(&.last_sent_content) || result.content.presence
       return unless response_content
 
       save_to_session(session, "[Scheduled task] #{task_content}", response_content, result.tools_used)
@@ -251,7 +259,7 @@ module Autobot::Agent
       )
 
       result = @executor.execute(messages, @tools, session_key: session.key)
-      final_content = result.content || "Background task completed."
+      final_content = result.content.presence || "Background task completed."
 
       session.add_message(Constants::ROLE_USER, msg.content)
       session.add_message(Constants::ROLE_ASSISTANT, final_content)
@@ -301,6 +309,8 @@ module Autobot::Agent
       enabled_tools : Array(String),
       filesystem_roots : Array(String),
       web_allowed_domains : Array(String),
+      max_tokens : Int32 = Config::AgentDefaults.new.max_tokens,
+      temperature : Float64 = Config::AgentDefaults.new.temperature,
     ) : Nil
       subagents = SubagentManager.new(
         provider: @provider,
@@ -316,6 +326,8 @@ module Autobot::Agent
         enabled_tools: enabled_tools,
         filesystem_roots: filesystem_roots,
         web_allowed_domains: web_allowed_domains,
+        max_tokens: max_tokens,
+        temperature: temperature,
       )
       @tools.register(Tools::SpawnTool.new(subagents))
 

--- a/src/autobot/agent/memory_manager.cr
+++ b/src/autobot/agent/memory_manager.cr
@@ -27,6 +27,7 @@ module Autobot::Agent
       @model : String,
       @memory_window : Int32,
       @sessions : Session::Manager,
+      @max_tokens : Int32 = Config::AgentDefaults.new.max_tokens,
     )
       @memory = MemoryStore.new(@workspace)
     end
@@ -128,7 +129,8 @@ module Autobot::Agent
           {"role" => JSON::Any.new(Constants::ROLE_SYSTEM), "content" => JSON::Any.new("You are a memory consolidation agent. Respond only with valid JSON.")},
           {"role" => JSON::Any.new(Constants::ROLE_USER), "content" => JSON::Any.new(prompt)},
         ],
-        model: @model
+        model: @model,
+        max_tokens: @max_tokens
       )
 
       result = parse_result((response.content || "").strip)

--- a/src/autobot/agent/subagent.cr
+++ b/src/autobot/agent/subagent.cr
@@ -58,6 +58,8 @@ module Autobot
         @enabled_tools : Array(String) = [] of String,
         @filesystem_roots : Array(String) = [] of String,
         @web_allowed_domains : Array(String) = [] of String,
+        @max_tokens : Int32 = Config::AgentDefaults.new.max_tokens,
+        @temperature : Float64 = Config::AgentDefaults.new.temperature,
       )
         @context = Context::Builder.new(@workspace)
       end
@@ -132,13 +134,15 @@ module Autobot
             provider: @provider,
             context: @context,
             model: @model || @provider.default_model,
-            max_iterations: MAX_ITERATIONS
+            max_iterations: MAX_ITERATIONS,
+            max_tokens: @max_tokens,
+            temperature: @temperature
           )
 
           messages = build_initial_messages(task)
           result = executor.execute(messages, tools)
 
-          final_result = result.content || "Task completed but no final response was generated."
+          final_result = result.content.presence || "Task completed but no final response was generated."
 
           Log.info { "Subagent [#{task_id}] completed successfully" }
           announce_result(task_id, label, task, final_result, origin, Status::Ok)

--- a/src/autobot/agent/tool_executor.cr
+++ b/src/autobot/agent/tool_executor.cr
@@ -37,6 +37,8 @@ module Autobot::Agent
       @context : Context::Builder,
       @model : String,
       @max_iterations : Int32 = 20,
+      @max_tokens : Int32 = Config::AgentDefaults.new.max_tokens,
+      @temperature : Float64 = Config::AgentDefaults.new.temperature,
     )
     end
 
@@ -109,7 +111,9 @@ module Autobot::Agent
       response = @provider.chat(
         messages: messages,
         tools: tools.definitions(exclude: exclude_tools, compact: compact_tools),
-        model: @model
+        model: @model,
+        max_tokens: @max_tokens,
+        temperature: @temperature,
       )
 
       usage = response.usage

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -399,7 +399,6 @@ module Autobot::Channels
       html = MarkdownToTelegramHTML.strip_html(html) unless MarkdownToTelegramHTML.valid_html?(html)
 
       MarkdownToTelegramHTML.split_message(html).each do |chunk|
-        next if chunk.strip.empty?
         send_html_chunk(message.chat_id, chunk)
       end
     end

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -393,10 +393,13 @@ module Autobot::Channels
         return
       end
 
+      return if message.content.strip.empty?
+
       html = MarkdownToTelegramHTML.convert(message.content)
       html = MarkdownToTelegramHTML.strip_html(html) unless MarkdownToTelegramHTML.valid_html?(html)
 
       MarkdownToTelegramHTML.split_message(html).each do |chunk|
+        next if chunk.strip.empty?
         send_html_chunk(message.chat_id, chunk)
       end
     end

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -144,6 +144,9 @@ module Autobot
         sandbox_config = config.tools.try(&.sandbox) || "auto"
         deny_patterns, allow_patterns = SetupHelper.load_exec_patterns(config)
 
+        agent_defaults = Config::AgentDefaults.new
+        defaults = config.agents.try(&.defaults)
+
         Autobot::Agent::Loop.new(
           bus: bus,
           provider: provider,
@@ -151,8 +154,8 @@ module Autobot
           tools: tool_registry,
           sessions: session_manager,
           model: config.default_model,
-          max_iterations: config.agents.try(&.defaults.try(&.max_tool_iterations)) || 20,
-          memory_window: config.agents.try(&.defaults.try(&.memory_window)) || 50,
+          max_iterations: defaults.try(&.max_tool_iterations) || 20,
+          memory_window: defaults.try(&.memory_window) || 50,
           cron_service: cron_service,
           brave_api_key: config.tools.try(&.web.try(&.search.try(&.api_key))),
           exec_timeout: config.tools.try(&.exec.try(&.timeout)) || 60,
@@ -163,6 +166,8 @@ module Autobot
           enabled_tools: config.tools.try(&.enabled) || [] of String,
           filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
           web_allowed_domains: config.tools.try(&.web.try(&.allowed_domains)) || [] of String,
+          max_tokens: defaults.try(&.max_tokens) || agent_defaults.max_tokens,
+          temperature: defaults.try(&.temperature) || agent_defaults.temperature,
         )
       end
 


### PR DESCRIPTION
## Summary
Propagates `max_tokens` and `temperature` from config through Gateway, Loop, SubagentManager, and ToolExecutor down to `Provider#chat`. In addition, prevents empty LLM responses from being emitted or recorded in session histories and adds empty outbound message protection in `TelegramChannel`.

### Root Cause
1. While `max_tokens` and `temperature` can be specified under `agents.defaults`, these options were not being forwarded through `ToolExecutor` to `Provider#chat`.
2. When an LLM returns an empty string or whitespace-only response (e.g. following certain tool invocations or token exhaustion), the empty string was saved to memory and dispatched to channels, leading to empty messages and Telegram API 400 Bad Request errors (`Bad Request: message text is empty`).

### Changes
- Propagate `max_tokens` and `temperature` in `ToolExecutor`, `Agent::Loop`, and `SubagentManager`.
- Use `String#presence || FALLBACK_RESPONSE` in `Agent::Loop` and `SubagentManager` so empty LLM responses default to a helpful fallback message rather than emitting blank strings.
- Guard `TelegramChannel#send_message` against empty or whitespace-only strings to avoid sending invalid payload to Telegram API.
- Add regression specs across `loop_spec.cr`, `tool_executor_spec.cr`, and `telegram_spec.cr`.

Closes #106

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>