### PR TITLE
fix(providers): send image blocks to Gemini and keep Telegram image documents for vision

### DIFF
--- a/spec/autobot/channels/telegram_media_spec.cr
+++ b/spec/autobot/channels/telegram_media_spec.cr
@@ -170,6 +170,19 @@ describe Autobot::Channels::TelegramMedia do
       attachments.first.mime_type.should eq("application/pdf")
     end
 
+    it "keeps document bytes for vision when mime type is an image" do
+      media = build_media(bytes: "png-bytes".to_slice)
+      msg = message(%({"document": {"file_id": "d2", "file_name": "photo.png", "mime_type": "image/png"}}))
+
+      parts, attachments = media.extract(msg, typed_text: false)
+
+      parts.should eq(["[document: photo.png]"])
+      attachment = attachments.first
+      attachment.name.should eq("photo.png")
+      attachment.mime_type.should eq("image/png")
+      attachment.data.should eq(Base64.strict_encode("png-bytes"))
+    end
+
     it "returns nothing for a plain text message" do
       media = build_media
       parts, attachments = media.extract(message(%({"text": "hello"})), typed_text: true)

--- a/spec/autobot/providers/gemini_provider_spec.cr
+++ b/spec/autobot/providers/gemini_provider_spec.cr
@@ -39,4 +39,30 @@ describe Autobot::Providers::GeminiProvider do
     parts[1]["inlineData"]["mimeType"].as_s.should eq("image/png")
     parts[1]["inlineData"]["data"].as_s.should eq("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
   end
+
+  it "drops image blocks whose url is not a base64 data URI" do
+    provider = TestableGeminiProvider.new(api_key: "test_key", model: "gemini-3.7-flash")
+
+    messages = [
+      {
+        "role"    => JSON::Any.new("user"),
+        "content" => JSON::Any.new([
+          JSON::Any.new({
+            "type" => JSON::Any.new("text"),
+            "text" => JSON::Any.new("Describe this"),
+          } of String => JSON::Any),
+          JSON::Any.new({
+            "type"      => JSON::Any.new("image_url"),
+            "image_url" => JSON::Any.new({
+              "url" => JSON::Any.new("https://example.com/photo.png"),
+            } of String => JSON::Any),
+          } of String => JSON::Any),
+        ]),
+      },
+    ]
+
+    parts = provider.test_map_messages_to_native(messages).first["parts"].as_a
+    parts.size.should eq(1)
+    parts[0]["text"].as_s.should eq("Describe this")
+  end
 end

--- a/spec/autobot/providers/gemini_provider_spec.cr
+++ b/spec/autobot/providers/gemini_provider_spec.cr
@@ -1,0 +1,42 @@
+require "../../spec_helper"
+
+class TestableGeminiProvider < Autobot::Providers::GeminiProvider
+  def test_map_messages_to_native(messages)
+    map_messages_to_native(messages)
+  end
+end
+
+describe Autobot::Providers::GeminiProvider do
+  it "maps multimodal text and image blocks to native inlineData parts" do
+    provider = TestableGeminiProvider.new(api_key: "test_key", model: "gemini-3.7-flash")
+
+    messages = [
+      {
+        "role"    => JSON::Any.new("user"),
+        "content" => JSON::Any.new([
+          JSON::Any.new({
+            "type" => JSON::Any.new("text"),
+            "text" => JSON::Any.new("What is in this image?"),
+          } of String => JSON::Any),
+          JSON::Any.new({
+            "type"      => JSON::Any.new("image_url"),
+            "image_url" => JSON::Any.new({
+              "url" => JSON::Any.new("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="),
+            } of String => JSON::Any),
+          } of String => JSON::Any),
+        ]),
+      },
+    ]
+
+    contents = provider.test_map_messages_to_native(messages)
+    contents.size.should eq(1)
+    user_content = contents.first
+    user_content["role"].as_s.should eq("user")
+
+    parts = user_content["parts"].as_a
+    parts.size.should eq(2)
+    parts[0]["text"].as_s.should eq("What is in this image?")
+    parts[1]["inlineData"]["mimeType"].as_s.should eq("image/png")
+    parts[1]["inlineData"]["data"].as_s.should eq("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+  end
+end

--- a/src/autobot/channels/telegram_media.cr
+++ b/src/autobot/channels/telegram_media.cr
@@ -70,8 +70,12 @@ module Autobot::Channels
       document = msg["document"]?
       return nil unless document
 
-      build(Bus::MediaAttachment::TYPE_DOCUMENT, document, origin,
-        format_of(document, Bus::MediaAttachment::TYPE_DOCUMENT, Media::Types::DEFAULT[1]), fetch(document),
+      format = format_of(document, Bus::MediaAttachment::TYPE_DOCUMENT, Media::Types::DEFAULT[1])
+      bytes = fetch(document)
+      data = format[1].starts_with?("image/") && bytes ? Base64.strict_encode(bytes) : nil
+
+      build(Bus::MediaAttachment::TYPE_DOCUMENT, document, origin, format, bytes,
+        data: data,
         name: string_of(document, "file_name"))
     end
 

--- a/src/autobot/providers/gemini_provider.cr
+++ b/src/autobot/providers/gemini_provider.cr
@@ -448,6 +448,8 @@ module Autobot
         if !has_thought_parts
           if text = msg["content"]?.try(&.as_s?)
             parts << {"text" => JSON::Any.new(text)}
+          elsif blocks = msg["content"]?.try(&.as_a?)
+            append_multimodal_blocks(parts, blocks)
           end
         end
 
@@ -460,6 +462,39 @@ module Autobot
         end
 
         parts
+      end
+
+      private def append_multimodal_blocks(parts : Array(Hash(String, JSON::Any)), blocks : Array(JSON::Any)) : Nil
+        blocks.each do |block|
+          case block["type"]?.try(&.as_s?)
+          when "text"
+            if b_text = block["text"]?.try(&.as_s?)
+              parts << {"text" => JSON::Any.new(b_text)}
+            end
+          when "image_url"
+            append_image_url_block(parts, block)
+          end
+        end
+      end
+
+      private def append_image_url_block(parts : Array(Hash(String, JSON::Any)), block : JSON::Any) : Nil
+        img_url = block["image_url"]?.try { |image_obj| image_obj["url"]?.try(&.as_s?) }
+        return unless img_url
+        return unless img_url.starts_with?("data:")
+
+        comma_idx = img_url.index(',')
+        return unless comma_idx
+
+        header = img_url[5...comma_idx]
+        mime_type = header.split(';').first
+        b64_data = img_url[(comma_idx + 1)..]
+
+        parts << {
+          "inlineData" => JSON::Any.new({
+            "mimeType" => JSON::Any.new(mime_type),
+            "data"     => JSON::Any.new(b64_data),
+          } of String => JSON::Any),
+        }
       end
 
       private def extract_thought_parts(tcalls) : Array(Hash(String, JSON::Any))?

--- a/src/autobot/providers/gemini_provider.cr
+++ b/src/autobot/providers/gemini_provider.cr
@@ -468,8 +468,8 @@ module Autobot
         blocks.each do |block|
           case block["type"]?.try(&.as_s?)
           when "text"
-            if b_text = block["text"]?.try(&.as_s?)
-              parts << {"text" => JSON::Any.new(b_text)}
+            if text = block["text"]?.try(&.as_s?)
+              parts << {"text" => JSON::Any.new(text)}
             end
           when "image_url"
             append_image_url_block(parts, block)
@@ -478,21 +478,14 @@ module Autobot
       end
 
       private def append_image_url_block(parts : Array(Hash(String, JSON::Any)), block : JSON::Any) : Nil
-        img_url = block["image_url"]?.try { |image_obj| image_obj["url"]?.try(&.as_s?) }
-        return unless img_url
-        return unless img_url.starts_with?("data:")
+        url = block["image_url"]?.try { |image| image["url"]?.try(&.as_s?) } || ""
+        return unless parsed = parse_data_uri(url)
 
-        comma_idx = img_url.index(',')
-        return unless comma_idx
-
-        header = img_url[5...comma_idx]
-        mime_type = header.split(';').first
-        b64_data = img_url[(comma_idx + 1)..]
-
+        mime_type, data = parsed
         parts << {
           "inlineData" => JSON::Any.new({
             "mimeType" => JSON::Any.new(mime_type),
-            "data"     => JSON::Any.new(b64_data),
+            "data"     => JSON::Any.new(data),
           } of String => JSON::Any),
         }
       end

--- a/src/autobot/providers/http_provider.cr
+++ b/src/autobot/providers/http_provider.cr
@@ -300,7 +300,7 @@ module Autobot
       private def convert_image_url_to_anthropic(block : JSON::Any) : JSON::Any
         url = block["image_url"]?.try { |image_url| image_url["url"]?.try(&.as_s?) } || ""
 
-        media_type, data = parse_data_uri(url)
+        media_type, data = parse_data_uri(url) || {"image/jpeg", url}
 
         JSON::Any.new({
           "type"   => JSON::Any.new("image"),
@@ -310,17 +310,6 @@ module Autobot
             "data"       => JSON::Any.new(data),
           } of String => JSON::Any),
         } of String => JSON::Any)
-      end
-
-      private def parse_data_uri(url : String) : {String, String}
-        if url.starts_with?("data:") && url.includes?(";base64,")
-          parts = url.split(";base64,", 2)
-          media_type = parts[0].lchop("data:")
-          data = parts[1]
-          {media_type, data}
-        else
-          {"image/jpeg", url}
-        end
       end
 
       # Convert tool definitions to Anthropic format.

--- a/src/autobot/providers/provider.cr
+++ b/src/autobot/providers/provider.cr
@@ -4,6 +4,9 @@ module Autobot
     DEFAULT_MAX_TOKENS  = 4096
     DEFAULT_TEMPERATURE =  0.7
 
+    DATA_URI_PREFIX      = "data:"
+    BASE64_URI_SEPARATOR = ";base64,"
+
     # Abstract base for LLM providers.
     #
     # Implementations handle the specifics of each provider's API
@@ -32,6 +35,13 @@ module Autobot
       # tool schemas remain stable and don't bust the cache.
       def supports_progressive_disclosure? : Bool
         true
+      end
+
+      private def parse_data_uri(url : String) : {String, String}?
+        return unless url.starts_with?(DATA_URI_PREFIX) && url.includes?(BASE64_URI_SEPARATOR)
+
+        header, data = url.split(BASE64_URI_SEPARATOR, 2)
+        {header.lchop(DATA_URI_PREFIX), data}
       end
     end
   end


### PR DESCRIPTION
## Summary
Makes Gemini requests work when the user turn carries images, and lets Telegram documents that are really images reach the model as vision input.

### Root cause
1. `GeminiProvider#build_native_parts` only handled string content. When `Context::Builder` produced a multimodal array (`text` + `image_url` blocks) the user turn was dropped, so the request ended on a `model` turn and Gemini answered 400 `Requests ending with a model turn are not supported`.
2. `TelegramMedia#extract_document` never set `data` for documents, so images sent as uncompressed files were described to the model but not shown to it.

### Changes
- `GeminiProvider`: map `text` blocks to `text` parts and `image_url` data URIs to `inlineData` parts.
- `Provider`: share the base64 data URI parser between the HTTP and Gemini providers.
- `TelegramMedia`: keep the downloaded bytes as `data` when a document's MIME type is `image/*`.
- Specs for both paths in `gemini_provider_spec.cr` and `telegram_media_spec.cr`.

Closes #107

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>