### PR TITLE
ci: run lint as a dedicated job and cover spec/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: shards install
+
+      - name: Check formatting
+        run: crystal tool format --check src/ spec/
+
+      - name: Run linter
+        run: |
+          mkdir -p bin
+          crystal build -o bin/ameba lib/ameba/bin/ameba.cr
+          bin/ameba src/ spec/
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -20,15 +40,6 @@ jobs:
 
       - name: Install dependencies
         run: shards install
-
-      - name: Check formatting
-        run: crystal tool format --check src/ spec/
-
-      - name: Run linter
-        run: |
-          mkdir -p bin
-          crystal build -o bin/ameba lib/ameba/bin/ameba.cr
-          bin/ameba src/
 
       - name: Run tests
         run: crystal spec --progress


### PR DESCRIPTION
## Summary

- Split formatting and ameba checks out of the **Test** job into a dedicated **Lint** job, so lint failures show up as their own check on PRs.
- Extend ameba coverage to `spec/` (previously only `src/` was linted). Spec-only style violations currently pass CI unnoticed — see the 17 `Style/MultilineStringLiteral` findings on #105.
- Both `src/` and `spec/` are clean on `main` (142 files, 0 failures), so this does not break existing CI.

The Test job keeps its sqlite3 system dependency; the Lint job doesn't need it.