### PR TITLE
feat(media): classify incoming media and save attachments to an inbox

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,17 @@ Voice messages are automatically transcribed using the Whisper API when a suppor
 
 If neither Groq nor OpenAI is configured, voice messages fall back to `[voice message]` text.
 
+## Media
+
+Incoming files are saved to an inbox under the workspace so tools can read them by path. Only the location is configurable:
+
+```yaml
+media:
+  inbox: inbox   # relative to the workspace (default), or an absolute path
+```
+
+A voice note recorded in the chat by the sender is treated as their spoken words. Audio files, photos, documents and anything forwarded become attachments and never enter the message text. See [Media support](media.md).
+
 ## Channels
 
 **Security Note:** `allow_from` is deny-by-default for security.

--- a/docs/media.md
+++ b/docs/media.md
@@ -4,7 +4,52 @@ Autobot handles media in three directions:
 
 - **Vision (inbound)** — photos sent by users are downloaded, base64-encoded, and forwarded to the LLM as multimodal content blocks
 - **Image generation (outbound)** — the LLM can create images via the `generate_image` tool and send them back to users
-- **Voice transcription (inbound)** — voice messages are transcribed to text via the Whisper API before reaching the LLM
+- **Voice transcription (inbound)** — voice notes are transcribed to text via the Whisper API before reaching the LLM
+
+## Spoken is instruction, attached is content
+
+Every incoming media message is classified before the agent sees it:
+
+| What arrives | Treated as | Why |
+|--------------|------------|-----|
+| Typed text | instruction | The user's words |
+| Voice note recorded in the chat by the sender | instruction | The user's words, spoken. Transcribed into the message text |
+| Audio file, photo, document | content | Something handed over. Becomes an attachment |
+| Anything forwarded, voice notes included | content | The words are not the sender's. Becomes an attachment |
+| Typed text with media | text is the instruction, media is content | A caption or a message with a file |
+
+Content never enters the message text. An audio file is transcribed when a
+transcriber is available, but the transcript lives on the attachment
+(`transcript`, `transcript_path`), not in `content`, so nothing inside a
+recording can pass as an instruction from the user.
+
+### The inbox
+
+Incoming media files are saved under the workspace so agents and tools can
+read them by path:
+
+```yaml
+media:
+  inbox: inbox   # relative to the workspace, default
+```
+
+Each file gets a unique timestamped name and the extension of its MIME type.
+Transcripts of content attachments are written next to the media file as
+`.txt`. The directory is created with mode `0700` and files with `0600`.
+
+### Attachment fields
+
+`MediaAttachment` carries what the classification needs:
+
+| Field | Meaning |
+|-------|---------|
+| `type` | `photo`, `voice`, `audio`, `document`, `video` |
+| `origin` | `sender` or `forwarded` |
+| `file_path` | Where the file was saved in the inbox |
+| `transcript`, `transcript_path` | Transcript of a content attachment |
+| `duration_seconds`, `name`, `mime_type`, `size_bytes` | Metadata from the platform |
+
+`spoken_instruction?` is true only for a voice note with origin `sender`.
 
 ## Vision
 
@@ -196,18 +241,19 @@ LLM generates file (exec tool) -> message(content, file_path) -> Read & base64 e
 
 ## Voice transcription
 
-Voice and audio messages received via Telegram are automatically transcribed to text using the Whisper API before being sent to the LLM.
+Voice notes and audio files received via Telegram are transcribed using the Whisper API. Where the text ends up depends on the classification above.
 
 ### How it works
 
 ```
-Telegram voice -> Download OGG -> Transcriber (Whisper API) -> Text in message content -> LLM
+Voice note from the sender -> Download -> Transcriber -> "[voice transcription]: ..." in message content -> LLM
+Audio file or forwarded note -> Download -> Transcriber -> transcript on the attachment            -> LLM
 ```
 
-1. **Channel** receives a voice/audio message and downloads the file bytes
+1. **Channel** receives a voice note or audio file and downloads the file bytes
 2. **Transcriber** sends the audio to the Whisper API (OpenAI or Groq) and receives text
-3. The transcribed text replaces the `[voice message]` placeholder as `[voice transcription]: {text}`
-4. The LLM receives the transcription as regular text content
+3. For a voice note the sender recorded, with no typed text, the transcript becomes the message content as `[voice transcription]: {text}`
+4. For an audio file, a forwarded voice note, or a voice note with typed text, the transcript is stored on the attachment and the message content only carries a label such as `[audio: title]`
 
 ### Configuration
 
@@ -227,7 +273,7 @@ providers:
     api_key: "${OPENAI_API_KEY}"  # Voice transcription auto-enabled via OpenAI Whisper
 ```
 
-Groq is preferred when both are configured (faster, has free tier). If neither is configured, voice messages fall back to `[voice message]` text with no errors.
+Groq is preferred when both are configured (faster, has free tier). If neither is configured, voice notes fall back to `[voice message]` text with no errors, and audio files arrive as attachments without a transcript.
 
 ### Supported providers
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -43,13 +43,13 @@ Transcripts of content attachments are written next to the media file as
 
 | Field | Meaning |
 |-------|---------|
-| `type` | `photo`, `voice`, `audio`, `document`, `video` |
+| `type` | `photo`, `voice`, `audio`, `document` |
 | `origin` | `sender` or `forwarded` |
 | `file_path` | Where the file was saved in the inbox |
 | `transcript`, `transcript_path` | Transcript of a content attachment |
 | `duration_seconds`, `name`, `mime_type`, `size_bytes` | Metadata from the platform |
 
-`spoken_instruction?` is true only for a voice note with origin `sender`.
+`sender_voice_note?` is true only for a voice note with origin `sender`; the channel treats such a note as spoken words unless typed text came with it.
 
 ## Vision
 
@@ -226,7 +226,8 @@ LLM generates file (exec tool) -> message(content, file_path) -> Read & base64 e
 | `.mp4` | video | `sendDocument` |
 | `.pdf` | document | `sendDocument` |
 | `.ogg` | voice | `sendVoice` |
-| `.mp3`, `.wav` | audio | `sendAudio` |
+| `.mp3`, `.m4a`, `.wav`, `.webm` | audio | `sendAudio` |
+| `.txt` | document | `sendDocument` |
 | Other | document | `sendDocument` |
 
 ### Supported channels

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -99,9 +99,10 @@ channels:
 
 - **Long polling** — no webhook or public IP needed
 - **Reply context** — when replying to a message, the original text is included as context so the bot understands what you're referring to
-- **Voice messages** — auto-transcribed via Whisper (requires Groq or OpenAI provider)
-- **Photos** — sent as image attachments to the LLM
-- **Documents** — attached to the message context
+- **Voice notes** — a note recorded in the chat is auto-transcribed via Whisper into the message text (requires Groq or OpenAI provider)
+- **Audio files and forwarded voice notes** — saved to the inbox as attachments; the transcript stays on the attachment, never in the message text
+- **Photos** — sent as image attachments to the LLM and saved to the inbox
+- **Documents** — saved to the inbox and attached to the message context
 - **Typing indicators** — shows "typing..." while the LLM responds
 - **Markdown rendering** — LLM responses are converted to Telegram HTML
 - **Group chats** — the bot only replies when addressed: mentioned by `@username` or replied to. Other group messages are ignored (no response, no access-denied notice).

--- a/spec/autobot/bus/events_spec.cr
+++ b/spec/autobot/bus/events_spec.cr
@@ -128,4 +128,41 @@ describe Autobot::Bus::MediaAttachment do
     media = Autobot::Bus::MediaAttachment.new(type: "photo")
     media.data.should be_nil
   end
+
+  it "defaults to the sender origin" do
+    media = Autobot::Bus::MediaAttachment.new(type: "voice")
+    media.origin.should eq("sender")
+    media.forwarded?.should be_false
+  end
+
+  it "treats only a sender's voice note as a spoken instruction" do
+    Autobot::Bus::MediaAttachment.new(type: "voice").spoken_instruction?.should be_true
+    Autobot::Bus::MediaAttachment.new(type: "voice", origin: "forwarded").spoken_instruction?.should be_false
+    Autobot::Bus::MediaAttachment.new(type: "audio").spoken_instruction?.should be_false
+    Autobot::Bus::MediaAttachment.new(type: "document").spoken_instruction?.should be_false
+  end
+
+  it "round-trips attachment details through JSON" do
+    media = Autobot::Bus::MediaAttachment.new(
+      type: "audio",
+      file_path: "/inbox/memo.m4a",
+      origin: "forwarded",
+      transcript: "spoken words",
+      transcript_path: "/inbox/memo.txt",
+      duration_seconds: 134,
+      name: "Car dealer"
+    )
+
+    parsed = Autobot::Bus::MediaAttachment.from_json(media.to_json)
+    parsed.origin.should eq("forwarded")
+    parsed.transcript.should eq("spoken words")
+    parsed.transcript_path.should eq("/inbox/memo.txt")
+    parsed.duration_seconds.should eq(134)
+    parsed.name.should eq("Car dealer")
+  end
+
+  it "parses attachments written before origin existed" do
+    parsed = Autobot::Bus::MediaAttachment.from_json(%({"type": "photo", "url": "f1"}))
+    parsed.origin.should eq("sender")
+  end
 end

--- a/spec/autobot/bus/events_spec.cr
+++ b/spec/autobot/bus/events_spec.cr
@@ -130,16 +130,14 @@ describe Autobot::Bus::MediaAttachment do
   end
 
   it "defaults to the sender origin" do
-    media = Autobot::Bus::MediaAttachment.new(type: "voice")
-    media.origin.should eq("sender")
-    media.forwarded?.should be_false
+    Autobot::Bus::MediaAttachment.new(type: "voice").origin.should eq("sender")
   end
 
-  it "treats only a sender's voice note as a spoken instruction" do
-    Autobot::Bus::MediaAttachment.new(type: "voice").spoken_instruction?.should be_true
-    Autobot::Bus::MediaAttachment.new(type: "voice", origin: "forwarded").spoken_instruction?.should be_false
-    Autobot::Bus::MediaAttachment.new(type: "audio").spoken_instruction?.should be_false
-    Autobot::Bus::MediaAttachment.new(type: "document").spoken_instruction?.should be_false
+  it "recognizes only a sender's voice note" do
+    Autobot::Bus::MediaAttachment.new(type: "voice").sender_voice_note?.should be_true
+    Autobot::Bus::MediaAttachment.new(type: "voice", origin: "forwarded").sender_voice_note?.should be_false
+    Autobot::Bus::MediaAttachment.new(type: "audio").sender_voice_note?.should be_false
+    Autobot::Bus::MediaAttachment.new(type: "document").sender_voice_note?.should be_false
   end
 
   it "round-trips attachment details through JSON" do

--- a/spec/autobot/channels/telegram_media_spec.cr
+++ b/spec/autobot/channels/telegram_media_spec.cr
@@ -1,0 +1,190 @@
+require "../../spec_helper"
+
+private class FakeTranscriber < Autobot::Transcriber
+  getter calls = [] of String
+
+  def initialize
+    super(api_key: "test", provider: "openai")
+  end
+
+  def transcribe(audio_data : Bytes, filename : String = "voice.ogg") : String?
+    @calls << filename
+    "spoken words"
+  end
+end
+
+private def fetcher(bytes : Bytes? = "audio-bytes".to_slice) : Autobot::Channels::TelegramMedia::Fetcher
+  ->(_file_id : String) : Bytes? { bytes }
+end
+
+private def message(json : String) : JSON::Any
+  JSON.parse(json)
+end
+
+private VOICE_NOTE = %({"voice": {"file_id": "v1", "mime_type": "audio/ogg", "duration": 7, "file_size": 512}})
+private AUDIO_FILE = %({"audio": {"file_id": "a1", "mime_type": "audio/mp4", "title": "Car dealer", "duration": 134}})
+
+describe Autobot::Channels::TelegramMedia do
+  describe "a voice note recorded by the sender" do
+    it "becomes the message text when nothing was typed" do
+      transcriber = FakeTranscriber.new
+      media = Autobot::Channels::TelegramMedia.new(fetcher, transcriber)
+
+      parts, attachments = media.extract(message(VOICE_NOTE), typed_text: false)
+
+      parts.should eq(["[voice transcription]: spoken words"])
+      attachments.size.should eq(1)
+      attachment = attachments.first
+      attachment.spoken_instruction?.should be_true
+      attachment.transcript.should be_nil
+      attachment.duration_seconds.should eq(7)
+      attachment.size_bytes.should eq(512)
+      transcriber.calls.should eq(["audio.ogg"])
+    end
+
+    it "falls back to a placeholder without a transcriber" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher)
+
+      parts, attachments = media.extract(message(VOICE_NOTE), typed_text: false)
+
+      parts.should eq(["[voice message]"])
+      attachments.first.transcript.should be_nil
+    end
+
+    it "is content when typed text accompanies it" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new)
+
+      parts, attachments = media.extract(message(VOICE_NOTE), typed_text: true)
+
+      parts.should be_empty
+      attachments.first.spoken_instruction?.should be_true
+      attachments.first.transcript.should eq("spoken words")
+    end
+  end
+
+  describe "a forwarded voice note" do
+    it "is content, with its transcript kept on the attachment" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new)
+      msg = message(%({"forward_origin": {"type": "user"}, "voice": {"file_id": "v2", "mime_type": "audio/ogg"}}))
+
+      parts, attachments = media.extract(msg, typed_text: false)
+
+      parts.should eq(["[voice message]"])
+      attachment = attachments.first
+      attachment.forwarded?.should be_true
+      attachment.spoken_instruction?.should be_false
+      attachment.transcript.should eq("spoken words")
+    end
+
+    it "recognizes the legacy forward fields" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher)
+      media.forwarded?(message(%({"forward_date": 1, "text": "hi"}))).should be_true
+      media.forwarded?(message(%({"forward_sender_name": "Someone", "text": "hi"}))).should be_true
+      media.forwarded?(message(%({"text": "hi"}))).should be_false
+    end
+  end
+
+  describe "an audio file" do
+    it "is content with its transcript on the attachment, never in the text" do
+      transcriber = FakeTranscriber.new
+      media = Autobot::Channels::TelegramMedia.new(fetcher, transcriber)
+
+      parts, attachments = media.extract(message(AUDIO_FILE), typed_text: false)
+
+      parts.should eq(["[audio: Car dealer]"])
+      attachment = attachments.first
+      attachment.type.should eq("audio")
+      attachment.spoken_instruction?.should be_false
+      attachment.transcript.should eq("spoken words")
+      attachment.name.should eq("Car dealer")
+      attachment.duration_seconds.should eq(134)
+      transcriber.calls.should eq(["audio.m4a"])
+    end
+
+    it "adds no text when a caption was typed" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new)
+
+      parts, attachments = media.extract(message(AUDIO_FILE), typed_text: true)
+
+      parts.should be_empty
+      attachments.first.transcript.should eq("spoken words")
+    end
+  end
+
+  describe "photos and documents" do
+    it "keeps photo bytes for vision and labels the message" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher("img".to_slice))
+      msg = message(%({"photo": [{"file_id": "small"}, {"file_id": "large", "file_size": 3}]}))
+
+      parts, attachments = media.extract(msg, typed_text: false)
+
+      parts.should eq(["[photo]"])
+      attachment = attachments.first
+      attachment.url.should eq("large")
+      attachment.data.should eq(Base64.strict_encode("img"))
+      attachment.mime_type.should eq("image/jpeg")
+    end
+
+    it "labels documents by file name" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher)
+      msg = message(%({"document": {"file_id": "d1", "file_name": "report.pdf", "mime_type": "application/pdf"}}))
+
+      parts, attachments = media.extract(msg, typed_text: false)
+
+      parts.should eq(["[document: report.pdf]"])
+      attachments.first.name.should eq("report.pdf")
+      attachments.first.mime_type.should eq("application/pdf")
+    end
+
+    it "returns nothing for a plain text message" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher)
+      parts, attachments = media.extract(message(%({"text": "hello"})), typed_text: true)
+      parts.should be_empty
+      attachments.should be_empty
+    end
+  end
+
+  describe "with an inbox" do
+    it "saves the media and the transcript and records their paths" do
+      dir = TestHelper.tmp_dir("inbox")
+      begin
+        inbox = Autobot::Media::Inbox.new(dir)
+        media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new, inbox)
+
+        _, attachments = media.extract(message(AUDIO_FILE), typed_text: true)
+
+        attachment = attachments.first
+        file_path = attachment.file_path.to_s
+        File.read(file_path).should eq("audio-bytes")
+        file_path.should end_with(".m4a")
+        File.read(attachment.transcript_path.to_s).should eq("spoken words")
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "saves a spoken voice note without a transcript file" do
+      dir = TestHelper.tmp_dir("inbox")
+      begin
+        inbox = Autobot::Media::Inbox.new(dir)
+        media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new, inbox)
+
+        _, attachments = media.extract(message(VOICE_NOTE), typed_text: false)
+
+        attachments.first.file_path.to_s.should end_with(".ogg")
+        attachments.first.transcript_path.should be_nil
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "records no path when the download failed" do
+      media = Autobot::Channels::TelegramMedia.new(fetcher(nil), FakeTranscriber.new, Autobot::Media::Inbox.new(Path["/nonexistent"]))
+
+      parts, attachments = media.extract(message(VOICE_NOTE), typed_text: false)
+
+      parts.should eq(["[voice message]"])
+      attachments.first.file_path.should be_nil
+    end
+  end
+end

--- a/spec/autobot/channels/telegram_media_spec.cr
+++ b/spec/autobot/channels/telegram_media_spec.cr
@@ -112,6 +112,27 @@ describe Autobot::Channels::TelegramMedia do
       transcriber.calls.should eq(["audio.m4a"])
     end
 
+    it "takes the format from the file name when the platform sends no mime type" do
+      transcriber = FakeTranscriber.new
+      media = build_media(transcriber)
+      msg = message(%({"audio": {"file_id": "a2", "file_name": "New Recording 6.m4a"}}))
+
+      _, attachments = media.extract(msg, typed_text: false)
+
+      attachments.first.mime_type.should eq("audio/mp4")
+      attachments.first.name.should eq("New Recording 6.m4a")
+      transcriber.calls.should eq(["audio.m4a"])
+    end
+
+    it "prefers the file name extension over a conflicting mime type" do
+      transcriber = FakeTranscriber.new
+      msg = message(%({"audio": {"file_id": "a3", "file_name": "memo.m4a", "mime_type": "audio/mpeg"}}))
+
+      build_media(transcriber).extract(msg, typed_text: false)
+
+      transcriber.calls.should eq(["audio.m4a"])
+    end
+
     it "adds no text when a caption was typed" do
       media = build_media(FakeTranscriber.new)
 
@@ -174,6 +195,14 @@ describe Autobot::Channels::TelegramMedia do
 
         attachments.first.file_path.to_s.should end_with(".ogg")
         attachments.first.transcript_path.should be_nil
+      end
+    end
+
+    it "names the saved file after the platform file name's extension" do
+      with_inbox do |inbox|
+        msg = message(%({"audio": {"file_id": "a2", "file_name": "New Recording 6.m4a"}}))
+        _, attachments = build_media(nil, inbox).extract(msg, typed_text: false)
+        attachments.first.file_path.to_s.should end_with(".m4a")
       end
     end
 

--- a/spec/autobot/channels/telegram_media_spec.cr
+++ b/spec/autobot/channels/telegram_media_spec.cr
@@ -17,6 +17,17 @@ private def fetcher(bytes : Bytes? = "audio-bytes".to_slice) : Autobot::Channels
   ->(_file_id : String) : Bytes? { bytes }
 end
 
+private def build_media(transcriber : Autobot::Transcriber? = nil, inbox : Autobot::Media::Inbox? = nil, bytes : Bytes? = "audio-bytes".to_slice) : Autobot::Channels::TelegramMedia
+  Autobot::Channels::TelegramMedia.new(fetcher(bytes), transcriber, inbox)
+end
+
+private def with_inbox(&)
+  dir = TestHelper.tmp_dir("inbox")
+  yield Autobot::Media::Inbox.new(dir)
+ensure
+  FileUtils.rm_rf(dir) if dir
+end
+
 private def message(json : String) : JSON::Any
   JSON.parse(json)
 end
@@ -28,14 +39,14 @@ describe Autobot::Channels::TelegramMedia do
   describe "a voice note recorded by the sender" do
     it "becomes the message text when nothing was typed" do
       transcriber = FakeTranscriber.new
-      media = Autobot::Channels::TelegramMedia.new(fetcher, transcriber)
+      media = build_media(transcriber)
 
       parts, attachments = media.extract(message(VOICE_NOTE), typed_text: false)
 
       parts.should eq(["[voice transcription]: spoken words"])
       attachments.size.should eq(1)
       attachment = attachments.first
-      attachment.spoken_instruction?.should be_true
+      attachment.sender_voice_note?.should be_true
       attachment.transcript.should be_nil
       attachment.duration_seconds.should eq(7)
       attachment.size_bytes.should eq(512)
@@ -43,7 +54,7 @@ describe Autobot::Channels::TelegramMedia do
     end
 
     it "falls back to a placeholder without a transcriber" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher)
+      media = build_media
 
       parts, attachments = media.extract(message(VOICE_NOTE), typed_text: false)
 
@@ -52,32 +63,32 @@ describe Autobot::Channels::TelegramMedia do
     end
 
     it "is content when typed text accompanies it" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new)
+      media = build_media(FakeTranscriber.new)
 
       parts, attachments = media.extract(message(VOICE_NOTE), typed_text: true)
 
       parts.should be_empty
-      attachments.first.spoken_instruction?.should be_true
+      attachments.first.sender_voice_note?.should be_true
       attachments.first.transcript.should eq("spoken words")
     end
   end
 
   describe "a forwarded voice note" do
     it "is content, with its transcript kept on the attachment" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new)
+      media = build_media(FakeTranscriber.new)
       msg = message(%({"forward_origin": {"type": "user"}, "voice": {"file_id": "v2", "mime_type": "audio/ogg"}}))
 
       parts, attachments = media.extract(msg, typed_text: false)
 
       parts.should eq(["[voice message]"])
       attachment = attachments.first
-      attachment.forwarded?.should be_true
-      attachment.spoken_instruction?.should be_false
+      attachment.origin.should eq("forwarded")
+      attachment.sender_voice_note?.should be_false
       attachment.transcript.should eq("spoken words")
     end
 
     it "recognizes the legacy forward fields" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher)
+      media = build_media
       media.forwarded?(message(%({"forward_date": 1, "text": "hi"}))).should be_true
       media.forwarded?(message(%({"forward_sender_name": "Someone", "text": "hi"}))).should be_true
       media.forwarded?(message(%({"text": "hi"}))).should be_false
@@ -87,14 +98,14 @@ describe Autobot::Channels::TelegramMedia do
   describe "an audio file" do
     it "is content with its transcript on the attachment, never in the text" do
       transcriber = FakeTranscriber.new
-      media = Autobot::Channels::TelegramMedia.new(fetcher, transcriber)
+      media = build_media(transcriber)
 
       parts, attachments = media.extract(message(AUDIO_FILE), typed_text: false)
 
       parts.should eq(["[audio: Car dealer]"])
       attachment = attachments.first
       attachment.type.should eq("audio")
-      attachment.spoken_instruction?.should be_false
+      attachment.sender_voice_note?.should be_false
       attachment.transcript.should eq("spoken words")
       attachment.name.should eq("Car dealer")
       attachment.duration_seconds.should eq(134)
@@ -102,7 +113,7 @@ describe Autobot::Channels::TelegramMedia do
     end
 
     it "adds no text when a caption was typed" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new)
+      media = build_media(FakeTranscriber.new)
 
       parts, attachments = media.extract(message(AUDIO_FILE), typed_text: true)
 
@@ -113,7 +124,7 @@ describe Autobot::Channels::TelegramMedia do
 
   describe "photos and documents" do
     it "keeps photo bytes for vision and labels the message" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher("img".to_slice))
+      media = build_media(bytes: "img".to_slice)
       msg = message(%({"photo": [{"file_id": "small"}, {"file_id": "large", "file_size": 3}]}))
 
       parts, attachments = media.extract(msg, typed_text: false)
@@ -126,7 +137,7 @@ describe Autobot::Channels::TelegramMedia do
     end
 
     it "labels documents by file name" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher)
+      media = build_media
       msg = message(%({"document": {"file_id": "d1", "file_name": "report.pdf", "mime_type": "application/pdf"}}))
 
       parts, attachments = media.extract(msg, typed_text: false)
@@ -137,7 +148,7 @@ describe Autobot::Channels::TelegramMedia do
     end
 
     it "returns nothing for a plain text message" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher)
+      media = build_media
       parts, attachments = media.extract(message(%({"text": "hello"})), typed_text: true)
       parts.should be_empty
       attachments.should be_empty
@@ -146,40 +157,28 @@ describe Autobot::Channels::TelegramMedia do
 
   describe "with an inbox" do
     it "saves the media and the transcript and records their paths" do
-      dir = TestHelper.tmp_dir("inbox")
-      begin
-        inbox = Autobot::Media::Inbox.new(dir)
-        media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new, inbox)
-
-        _, attachments = media.extract(message(AUDIO_FILE), typed_text: true)
+      with_inbox do |inbox|
+        _, attachments = build_media(FakeTranscriber.new, inbox).extract(message(AUDIO_FILE), typed_text: true)
 
         attachment = attachments.first
         file_path = attachment.file_path.to_s
         File.read(file_path).should eq("audio-bytes")
         file_path.should end_with(".m4a")
         File.read(attachment.transcript_path.to_s).should eq("spoken words")
-      ensure
-        FileUtils.rm_rf(dir)
       end
     end
 
     it "saves a spoken voice note without a transcript file" do
-      dir = TestHelper.tmp_dir("inbox")
-      begin
-        inbox = Autobot::Media::Inbox.new(dir)
-        media = Autobot::Channels::TelegramMedia.new(fetcher, FakeTranscriber.new, inbox)
-
-        _, attachments = media.extract(message(VOICE_NOTE), typed_text: false)
+      with_inbox do |inbox|
+        _, attachments = build_media(FakeTranscriber.new, inbox).extract(message(VOICE_NOTE), typed_text: false)
 
         attachments.first.file_path.to_s.should end_with(".ogg")
         attachments.first.transcript_path.should be_nil
-      ensure
-        FileUtils.rm_rf(dir)
       end
     end
 
     it "records no path when the download failed" do
-      media = Autobot::Channels::TelegramMedia.new(fetcher(nil), FakeTranscriber.new, Autobot::Media::Inbox.new(Path["/nonexistent"]))
+      media = build_media(FakeTranscriber.new, Autobot::Media::Inbox.new(Path["/nonexistent"]), bytes: nil)
 
       parts, attachments = media.extract(message(VOICE_NOTE), typed_text: false)
 

--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -30,8 +30,18 @@ class TelegramChannelTest < Autobot::Channels::TelegramChannel
     super
   end
 
+  property stubbed_file_bytes : Bytes? = nil
+
+  private def download_telegram_file_bytes(file_id : String) : Bytes?
+    @stubbed_file_bytes || super
+  end
+
   def test_access_denied_message(sender_id : String) : String
     access_denied_message(sender_id)
+  end
+
+  def test_build_content_and_media(msg : JSON::Any) : {String, Array(Autobot::Bus::MediaAttachment)}
+    build_content_and_media(msg)
   end
 
   def test_command_description(entry : Autobot::Config::CustomCommandEntry, name : String) : String
@@ -285,6 +295,37 @@ describe Autobot::Channels::TelegramChannel do
       result = channel.test_prepend_reply_context("ok", exact_text)
       result.should_not contain("...")
       result.should contain(exact_text)
+    end
+  end
+
+  describe "#build_content_and_media" do
+    it "uses typed text as the message and keeps a captioned file as an attachment" do
+      channel = build_channel
+      channel.stubbed_file_bytes = "bytes".to_slice
+      msg = JSON.parse(%({"caption": "Add to notes", "audio": {"file_id": "a1", "mime_type": "audio/mp4", "title": "Memo"}}))
+
+      content, media = channel.test_build_content_and_media(msg)
+
+      content.should eq("Add to notes")
+      media.size.should eq(1)
+      media.first.type.should eq("audio")
+      media.first.spoken_instruction?.should be_false
+    end
+
+    it "labels media when nothing was typed" do
+      channel = build_channel
+      channel.stubbed_file_bytes = "bytes".to_slice
+      msg = JSON.parse(%({"document": {"file_id": "d1", "file_name": "report.pdf"}}))
+
+      content, _ = channel.test_build_content_and_media(msg)
+
+      content.should eq("[document: report.pdf]")
+    end
+
+    it "reports an empty message when there is neither text nor media" do
+      content, media = build_channel.test_build_content_and_media(JSON.parse("{}"))
+      content.should eq("[empty message]")
+      media.should be_empty
     end
   end
 

--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -309,7 +309,7 @@ describe Autobot::Channels::TelegramChannel do
       content.should eq("Add to notes")
       media.size.should eq(1)
       media.first.type.should eq("audio")
-      media.first.spoken_instruction?.should be_false
+      media.first.sender_voice_note?.should be_false
     end
 
     it "labels media when nothing was typed" do

--- a/spec/autobot/config/schema_spec.cr
+++ b/spec/autobot/config/schema_spec.cr
@@ -179,6 +179,34 @@ describe Autobot::Config::Config do
     end
   end
 
+  describe "#inbox_path" do
+    it "defaults to inbox under the workspace" do
+      config = Autobot::Config::Config.from_yaml("agents:\n  defaults:\n    workspace: /srv/bot/workspace\n")
+      config.inbox_path.should eq(Path["/srv/bot/workspace/inbox"])
+    end
+
+    it "resolves a relative media.inbox against the workspace" do
+      yaml = <<-YAML
+      agents:
+        defaults:
+          workspace: /srv/bot/workspace
+      media:
+        inbox: incoming/files
+      YAML
+
+      Autobot::Config::Config.from_yaml(yaml).inbox_path.should eq(Path["/srv/bot/workspace/incoming/files"])
+    end
+
+    it "keeps an absolute media.inbox" do
+      yaml = <<-YAML
+      media:
+        inbox: /srv/shared/inbox
+      YAML
+
+      Autobot::Config::Config.from_yaml(yaml).inbox_path.should eq(Path["/srv/shared/inbox"])
+    end
+  end
+
   describe "#default_model" do
     it "returns default when no agents configured" do
       config = empty_config

--- a/spec/autobot/media/inbox_spec.cr
+++ b/spec/autobot/media/inbox_spec.cr
@@ -9,9 +9,9 @@ end
 
 describe Autobot::Media::Inbox do
   describe "#store" do
-    it "writes the bytes with an extension from the mime type and private permissions" do
+    it "writes the bytes with the given extension and private permissions" do
       with_inbox do |inbox, dir|
-        path = inbox.store("hello".to_slice, "audio/ogg")
+        path = inbox.store("hello".to_slice, ".ogg")
 
         path.parent.should eq(dir)
         path.extension.should eq(".ogg")
@@ -23,23 +23,16 @@ describe Autobot::Media::Inbox do
     it "creates the directory with private permissions" do
       dir = TestHelper.tmp_dir("inbox")
       begin
-        Autobot::Media::Inbox.new(dir / "inbox").store("x".to_slice, "image/png")
+        Autobot::Media::Inbox.new(dir / "inbox").store("x".to_slice, ".png")
         File.info(dir / "inbox").permissions.value.should eq(0o700)
       ensure
         FileUtils.rm_rf(dir)
       end
     end
 
-    it "falls back to the given extension for unknown mime types" do
-      with_inbox do |inbox, _|
-        inbox.store("x".to_slice, "application/x-unknown", ".voice").extension.should eq(".voice")
-        inbox.store("x".to_slice, nil).extension.should eq(".bin")
-      end
-    end
-
     it "gives every file a distinct name" do
       with_inbox do |inbox, _|
-        inbox.store("a".to_slice, "image/jpeg").should_not eq(inbox.store("b".to_slice, "image/jpeg"))
+        inbox.store("a".to_slice, ".jpg").should_not eq(inbox.store("b".to_slice, ".jpg"))
       end
     end
   end
@@ -47,7 +40,7 @@ describe Autobot::Media::Inbox do
   describe "#store_transcript" do
     it "writes the transcript next to the media file" do
       with_inbox do |inbox, dir|
-        media = inbox.store("x".to_slice, "audio/mpeg")
+        media = inbox.store("x".to_slice, ".mp3")
         transcript = inbox.store_transcript("spoken words", media)
 
         transcript.should eq(dir / "#{media.stem}.txt")

--- a/spec/autobot/media/inbox_spec.cr
+++ b/spec/autobot/media/inbox_spec.cr
@@ -1,17 +1,29 @@
 require "../../spec_helper"
 
+private def with_inbox(&)
+  dir = TestHelper.tmp_dir("inbox")
+  yield Autobot::Media::Inbox.new(dir), dir
+ensure
+  FileUtils.rm_rf(dir) if dir
+end
+
 describe Autobot::Media::Inbox do
   describe "#store" do
-    it "writes the bytes under the inbox with an extension from the mime type" do
-      dir = TestHelper.tmp_dir("inbox")
-      begin
-        inbox = Autobot::Media::Inbox.new(dir / "inbox")
+    it "writes the bytes with an extension from the mime type and private permissions" do
+      with_inbox do |inbox, dir|
         path = inbox.store("hello".to_slice, "audio/ogg")
 
-        path.parent.should eq(dir / "inbox")
+        path.parent.should eq(dir)
         path.extension.should eq(".ogg")
         File.read(path).should eq("hello")
         File.info(path).permissions.value.should eq(0o600)
+      end
+    end
+
+    it "creates the directory with private permissions" do
+      dir = TestHelper.tmp_dir("inbox")
+      begin
+        Autobot::Media::Inbox.new(dir / "inbox").store("x".to_slice, "image/png")
         File.info(dir / "inbox").permissions.value.should eq(0o700)
       ensure
         FileUtils.rm_rf(dir)
@@ -19,48 +31,28 @@ describe Autobot::Media::Inbox do
     end
 
     it "falls back to the given extension for unknown mime types" do
-      dir = TestHelper.tmp_dir("inbox")
-      begin
-        inbox = Autobot::Media::Inbox.new(dir)
-        inbox.store("x".to_slice, "application/x-unknown", "voice").extension.should eq(".voice")
-        inbox.store("x".to_slice, nil, "bin").extension.should eq(".bin")
-      ensure
-        FileUtils.rm_rf(dir)
+      with_inbox do |inbox, _|
+        inbox.store("x".to_slice, "application/x-unknown", ".voice").extension.should eq(".voice")
+        inbox.store("x".to_slice, nil).extension.should eq(".bin")
       end
     end
 
     it "gives every file a distinct name" do
-      dir = TestHelper.tmp_dir("inbox")
-      begin
-        inbox = Autobot::Media::Inbox.new(dir)
-        first = inbox.store("a".to_slice, "image/jpeg")
-        second = inbox.store("b".to_slice, "image/jpeg")
-        first.should_not eq(second)
-      ensure
-        FileUtils.rm_rf(dir)
+      with_inbox do |inbox, _|
+        inbox.store("a".to_slice, "image/jpeg").should_not eq(inbox.store("b".to_slice, "image/jpeg"))
       end
     end
   end
 
   describe "#store_transcript" do
     it "writes the transcript next to the media file" do
-      dir = TestHelper.tmp_dir("inbox")
-      begin
-        inbox = Autobot::Media::Inbox.new(dir)
+      with_inbox do |inbox, dir|
         media = inbox.store("x".to_slice, "audio/mpeg")
         transcript = inbox.store_transcript("spoken words", media)
 
         transcript.should eq(dir / "#{media.stem}.txt")
         File.read(transcript).should eq("spoken words")
-      ensure
-        FileUtils.rm_rf(dir)
       end
-    end
-  end
-
-  describe ".extension_for" do
-    it "ignores mime parameters and case" do
-      Autobot::Media::Inbox.extension_for("Audio/OGG; codecs=opus", "bin").should eq("ogg")
     end
   end
 end

--- a/spec/autobot/media/inbox_spec.cr
+++ b/spec/autobot/media/inbox_spec.cr
@@ -1,0 +1,66 @@
+require "../../spec_helper"
+
+describe Autobot::Media::Inbox do
+  describe "#store" do
+    it "writes the bytes under the inbox with an extension from the mime type" do
+      dir = TestHelper.tmp_dir("inbox")
+      begin
+        inbox = Autobot::Media::Inbox.new(dir / "inbox")
+        path = inbox.store("hello".to_slice, "audio/ogg")
+
+        path.parent.should eq(dir / "inbox")
+        path.extension.should eq(".ogg")
+        File.read(path).should eq("hello")
+        File.info(path).permissions.value.should eq(0o600)
+        File.info(dir / "inbox").permissions.value.should eq(0o700)
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "falls back to the given extension for unknown mime types" do
+      dir = TestHelper.tmp_dir("inbox")
+      begin
+        inbox = Autobot::Media::Inbox.new(dir)
+        inbox.store("x".to_slice, "application/x-unknown", "voice").extension.should eq(".voice")
+        inbox.store("x".to_slice, nil, "bin").extension.should eq(".bin")
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "gives every file a distinct name" do
+      dir = TestHelper.tmp_dir("inbox")
+      begin
+        inbox = Autobot::Media::Inbox.new(dir)
+        first = inbox.store("a".to_slice, "image/jpeg")
+        second = inbox.store("b".to_slice, "image/jpeg")
+        first.should_not eq(second)
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+  end
+
+  describe "#store_transcript" do
+    it "writes the transcript next to the media file" do
+      dir = TestHelper.tmp_dir("inbox")
+      begin
+        inbox = Autobot::Media::Inbox.new(dir)
+        media = inbox.store("x".to_slice, "audio/mpeg")
+        transcript = inbox.store_transcript("spoken words", media)
+
+        transcript.should eq(dir / "#{media.stem}.txt")
+        File.read(transcript).should eq("spoken words")
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+  end
+
+  describe ".extension_for" do
+    it "ignores mime parameters and case" do
+      Autobot::Media::Inbox.extension_for("Audio/OGG; codecs=opus", "bin").should eq("ogg")
+    end
+  end
+end

--- a/spec/autobot/media/types_spec.cr
+++ b/spec/autobot/media/types_spec.cr
@@ -1,0 +1,26 @@
+require "../../spec_helper"
+
+describe Autobot::Media::Types do
+  describe ".for_extension" do
+    it "maps known extensions to a media type and mime" do
+      Autobot::Media::Types.for_extension(".M4A").should eq({"audio", "audio/mp4"})
+      Autobot::Media::Types.for_extension(".ogg").should eq({"voice", "audio/ogg"})
+    end
+
+    it "falls back to a generic document" do
+      Autobot::Media::Types.for_extension(".xyz").should eq({"document", "application/octet-stream"})
+    end
+  end
+
+  describe ".extension_for" do
+    it "ignores mime parameters and case" do
+      Autobot::Media::Types.extension_for("Audio/OGG; codecs=opus", ".bin").should eq(".ogg")
+    end
+
+    it "knows mime aliases and falls back otherwise" do
+      Autobot::Media::Types.extension_for("audio/x-m4a", ".bin").should eq(".m4a")
+      Autobot::Media::Types.extension_for("application/x-unknown", ".bin").should eq(".bin")
+      Autobot::Media::Types.extension_for(nil, ".bin").should eq(".bin")
+    end
+  end
+end

--- a/src/autobot/bus/events.cr
+++ b/src/autobot/bus/events.cr
@@ -34,11 +34,25 @@ module Autobot::Bus
   struct MediaAttachment
     include JSON::Serializable
 
-    property type : String # "photo", "voice", "document", "video"
+    TYPE_PHOTO    = "photo"
+    TYPE_VOICE    = "voice"
+    TYPE_AUDIO    = "audio"
+    TYPE_DOCUMENT = "document"
+    TYPE_VIDEO    = "video"
+
+    ORIGIN_SENDER    = "sender"
+    ORIGIN_FORWARDED = "forwarded"
+
+    property type : String
     property url : String?
     property file_path : String?
     property mime_type : String?
     property size_bytes : Int64?
+    property origin : String = ORIGIN_SENDER
+    property transcript : String?
+    property transcript_path : String?
+    property duration_seconds : Int32?
+    property name : String?
 
     @[JSON::Field(ignore: true)]
     property data : String?
@@ -50,7 +64,20 @@ module Autobot::Bus
       @mime_type : String? = nil,
       @size_bytes : Int64? = nil,
       @data : String? = nil,
+      @origin : String = ORIGIN_SENDER,
+      @transcript : String? = nil,
+      @transcript_path : String? = nil,
+      @duration_seconds : Int32? = nil,
+      @name : String? = nil,
     )
+    end
+
+    def forwarded? : Bool
+      origin == ORIGIN_FORWARDED
+    end
+
+    def spoken_instruction? : Bool
+      type == TYPE_VOICE && origin == ORIGIN_SENDER
     end
   end
 

--- a/src/autobot/bus/events.cr
+++ b/src/autobot/bus/events.cr
@@ -38,7 +38,6 @@ module Autobot::Bus
     TYPE_VOICE    = "voice"
     TYPE_AUDIO    = "audio"
     TYPE_DOCUMENT = "document"
-    TYPE_VIDEO    = "video"
 
     ORIGIN_SENDER    = "sender"
     ORIGIN_FORWARDED = "forwarded"
@@ -72,11 +71,7 @@ module Autobot::Bus
     )
     end
 
-    def forwarded? : Bool
-      origin == ORIGIN_FORWARDED
-    end
-
-    def spoken_instruction? : Bool
+    def sender_voice_note? : Bool
       type == TYPE_VOICE && origin == ORIGIN_SENDER
     end
   end

--- a/src/autobot/channels/manager.cr
+++ b/src/autobot/channels/manager.cr
@@ -24,6 +24,7 @@ module Autobot::Channels
 
     getter channels : Hash(String, Channel) = {} of String => Channel
     getter transcriber : Transcriber? = nil
+    @inbox : Media::Inbox
 
     def initialize(
       @config : Config::Config,
@@ -32,6 +33,7 @@ module Autobot::Channels
       @cron_service : Cron::Service? = nil,
     )
       @transcriber = detect_transcriber
+      @inbox = Media::Inbox.new(@config.inbox_path)
       init_channels
     end
 
@@ -130,7 +132,7 @@ module Autobot::Channels
         session_manager: @session_manager,
         transcriber: @transcriber,
         cron_service: @cron_service,
-        inbox: Media::Inbox.new(@config.inbox_path),
+        inbox: @inbox,
       )
       Log.info { "Telegram channel enabled" }
     end

--- a/src/autobot/channels/manager.cr
+++ b/src/autobot/channels/manager.cr
@@ -8,6 +8,7 @@ require "../config/schema"
 require "../bus/queue"
 require "../cron/service"
 require "../transcriber"
+require "../media/inbox"
 
 module Autobot::Channels
   # Manages chat channels and coordinates message routing.
@@ -129,6 +130,7 @@ module Autobot::Channels
         session_manager: @session_manager,
         transcriber: @transcriber,
         cron_service: @cron_service,
+        inbox: Media::Inbox.new(@config.inbox_path),
       )
       Log.info { "Telegram channel enabled" }
     end

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -298,12 +298,15 @@ module Autobot::Channels
     TYPING_INTERVAL   = 4.0
     MAX_IMAGE_SIZE    = 20 * 1024 * 1024 # 20 MB
 
+    MEDIA_LOG_LABEL     = "[media]"
+    EMPTY_MESSAGE_LABEL = "[empty message]"
+
     @offset : Int64 = 0_i64
     @bot_username : String = ""
     @bot_mention_regex : Regex? = nil
     @typing_channels : Set(String) = Set(String).new
     @chat_log_mutex : Mutex = Mutex.new
-    @media_extractor : TelegramMedia?
+    @media_extractor : TelegramMedia
 
     def initialize(
       @bus : Bus::MessageBus,
@@ -317,6 +320,7 @@ module Autobot::Channels
       @inbox : Media::Inbox? = nil,
     )
       super(Constants::CHANNEL_TELEGRAM, @bus, @allow_from)
+      @media_extractor = TelegramMedia.new(->(file_id : String) { download_telegram_file_bytes(file_id) }, @transcriber, @inbox)
     end
 
     GETME_MAX_ATTEMPTS = 5
@@ -564,16 +568,12 @@ module Autobot::Channels
         end
       end
 
-      content, media_attachments = build_content_and_media(msg)
-      content = prepend_reply_context(content, extract_reply_context(msg))
-
       display_name = sender[:username] ? "@#{sender[:username]}" : sender[:first_name]
-      content_to_process = sender[:is_group] ? "#{display_name}: #{content}" : content
 
       # Record every group message (regardless of allowlist or mention) so the
       # rolling chat log stays complete.
       if sender[:is_group]
-        record_chat_log(sender[:chat_id], display_name, content)
+        record_chat_log(sender[:chat_id], display_name, typed_text(msg) || MEDIA_LOG_LABEL)
       end
 
       # Stay silent for group messages that do not address the bot, before the
@@ -588,6 +588,10 @@ module Autobot::Channels
         send_reply(sender[:chat_id], access_denied_message(sender[:sender_id]))
         return
       end
+
+      content, media_attachments = build_content_and_media(msg)
+      content = prepend_reply_context(content, extract_reply_context(msg))
+      content_to_process = sender[:is_group] ? "#{display_name}: #{content}" : content
 
       Log.debug { "Message from #{sender[:sender_id]}: #{content_to_process}" }
       start_typing(sender[:chat_id])
@@ -632,24 +636,18 @@ module Autobot::Channels
       reply_msg["text"]?.try(&.as_s) || reply_msg["caption"]?.try(&.as_s)
     end
 
-    private def build_content_and_media(msg : JSON::Any) : {String, Array(Bus::MediaAttachment)}
-      content_parts = [] of String
-      msg["text"]?.try(&.as_s?).try { |text| content_parts << text }
-      msg["caption"]?.try(&.as_s?).try { |caption| content_parts << caption }
-
-      media_parts, media_attachments = media_extractor.extract(msg, !content_parts.empty?)
-      content_parts.concat(media_parts)
-
-      content = content_parts.empty? ? "[empty message]" : content_parts.join("\n")
-      {content, media_attachments}
+    private def typed_text(msg : JSON::Any) : String?
+      parts = [msg["text"]?.try(&.as_s?), msg["caption"]?.try(&.as_s?)].compact
+      parts.empty? ? nil : parts.join("\n")
     end
 
-    private def media_extractor : TelegramMedia
-      @media_extractor ||= TelegramMedia.new(
-        ->(file_id : String) { download_telegram_file_bytes(file_id) },
-        @transcriber,
-        @inbox,
-      )
+    private def build_content_and_media(msg : JSON::Any) : {String, Array(Bus::MediaAttachment)}
+      typed = typed_text(msg)
+      media_parts, media_attachments = @media_extractor.extract(msg, !typed.nil?)
+
+      content_parts = [typed].compact.concat(media_parts)
+      content = content_parts.empty? ? EMPTY_MESSAGE_LABEL : content_parts.join("\n")
+      {content, media_attachments}
     end
 
     private def download_telegram_file_bytes(file_id : String) : Bytes?

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -3,6 +3,7 @@ require "http/client"
 require "json"
 require "uri"
 require "./base"
+require "./telegram_media"
 require "../constants"
 require "../cron/formatter"
 require "../cron/service"
@@ -302,6 +303,7 @@ module Autobot::Channels
     @bot_mention_regex : Regex? = nil
     @typing_channels : Set(String) = Set(String).new
     @chat_log_mutex : Mutex = Mutex.new
+    @media_extractor : TelegramMedia?
 
     def initialize(
       @bus : Bus::MessageBus,
@@ -312,6 +314,7 @@ module Autobot::Channels
       @session_manager : Session::Manager? = nil,
       @transcriber : Transcriber? = nil,
       @cron_service : Cron::Service? = nil,
+      @inbox : Media::Inbox? = nil,
     )
       super(Constants::CHANNEL_TELEGRAM, @bus, @allow_from)
     end
@@ -631,46 +634,22 @@ module Autobot::Channels
 
     private def build_content_and_media(msg : JSON::Any) : {String, Array(Bus::MediaAttachment)}
       content_parts = [] of String
-      media_attachments = [] of Bus::MediaAttachment
+      msg["text"]?.try(&.as_s?).try { |text| content_parts << text }
+      msg["caption"]?.try(&.as_s?).try { |caption| content_parts << caption }
 
-      if text = msg["text"]?.try(&.as_s)
-        content_parts << text
-      end
-      if caption = msg["caption"]?.try(&.as_s)
-        content_parts << caption
-      end
-
-      append_media_attachments(msg, content_parts, media_attachments)
+      media_parts, media_attachments = media_extractor.extract(msg, !content_parts.empty?)
+      content_parts.concat(media_parts)
 
       content = content_parts.empty? ? "[empty message]" : content_parts.join("\n")
       {content, media_attachments}
     end
 
-    private def append_media_attachments(msg : JSON::Any, content_parts : Array(String), media_attachments : Array(Bus::MediaAttachment)) : Nil
-      append_photo_attachment(msg, content_parts, media_attachments)
-      append_voice_attachment(msg, content_parts, media_attachments)
-      append_audio_attachment(msg, content_parts, media_attachments)
-      append_document_attachment(msg, content_parts, media_attachments)
-    end
-
-    private def append_photo_attachment(msg : JSON::Any, content_parts : Array(String), media_attachments : Array(Bus::MediaAttachment)) : Nil
-      if photos = msg["photo"]?.try(&.as_a?)
-        if last_photo = photos.last?
-          file_id = last_photo["file_id"].as_s
-          image_data = download_telegram_file(file_id)
-          media_attachments << Bus::MediaAttachment.new(
-            type: "photo", url: file_id, mime_type: "image/jpeg", data: image_data,
-          )
-          content_parts << "[photo]" if content_parts.empty?
-        end
-      end
-    end
-
-    private def download_telegram_file(file_id : String) : String?
-      bytes = download_telegram_file_bytes(file_id)
-      return nil unless bytes
-
-      Base64.strict_encode(bytes)
+    private def media_extractor : TelegramMedia
+      @media_extractor ||= TelegramMedia.new(
+        ->(file_id : String) { download_telegram_file_bytes(file_id) },
+        @transcriber,
+        @inbox,
+      )
     end
 
     private def download_telegram_file_bytes(file_id : String) : Bytes?
@@ -701,50 +680,6 @@ module Autobot::Channels
     rescue ex
       Log.error { "Error downloading telegram file: #{ex.message}" }
       nil
-    end
-
-    private def transcribe_file(file_id : String) : String?
-      transcriber = @transcriber
-      return nil unless transcriber
-
-      bytes = download_telegram_file_bytes(file_id)
-      return nil unless bytes
-
-      transcriber.transcribe(bytes)
-    end
-
-    private def append_voice_attachment(msg : JSON::Any, content_parts : Array(String), media_attachments : Array(Bus::MediaAttachment)) : Nil
-      if voice = msg["voice"]?
-        file_id = voice["file_id"].as_s
-        media_attachments << Bus::MediaAttachment.new(type: "voice", url: file_id, mime_type: voice["mime_type"]?.try(&.as_s) || "audio/ogg")
-
-        if content_parts.empty?
-          text = transcribe_file(file_id)
-          content_parts << (text ? "[voice transcription]: #{text}" : "[voice message]")
-        end
-      end
-    end
-
-    private def append_audio_attachment(msg : JSON::Any, content_parts : Array(String), media_attachments : Array(Bus::MediaAttachment)) : Nil
-      if audio = msg["audio"]?
-        file_id = audio["file_id"].as_s
-        media_attachments << Bus::MediaAttachment.new(type: "voice", url: file_id, mime_type: audio["mime_type"]?.try(&.as_s) || "audio/mpeg")
-
-        if content_parts.empty?
-          title = audio["title"]?.try(&.as_s) || "audio"
-          text = transcribe_file(file_id)
-          content_parts << (text ? "[voice transcription]: #{text}" : "[audio: #{title}]")
-        end
-      end
-    end
-
-    private def append_document_attachment(msg : JSON::Any, content_parts : Array(String), media_attachments : Array(Bus::MediaAttachment)) : Nil
-      if doc = msg["document"]?
-        file_id = doc["file_id"].as_s
-        file_name = doc["file_name"]?.try(&.as_s) || "unknown"
-        media_attachments << Bus::MediaAttachment.new(type: "document", url: file_id, mime_type: doc["mime_type"]?.try(&.as_s))
-        content_parts << "[document: #{file_name}]" if content_parts.empty?
-      end
     end
 
     private def build_metadata(msg : JSON::Any, sender : NamedTuple(chat_id: String, user_id: String, username: String?, first_name: String, sender_id: String, is_group: Bool)) : Hash(String, String)

--- a/src/autobot/channels/telegram_media.cr
+++ b/src/autobot/channels/telegram_media.cr
@@ -1,0 +1,147 @@
+require "base64"
+require "json"
+require "../bus/events"
+require "../media/inbox"
+require "../transcriber"
+
+module Autobot::Channels
+  # A voice note the sender recorded is their spoken words; files and forwards are content.
+  class TelegramMedia
+    alias Fetcher = Proc(String, Bytes?)
+
+    FORWARD_KEYS = %w[forward_origin forward_from forward_from_chat forward_sender_name forward_date]
+
+    PHOTO_MIME    = "image/jpeg"
+    VOICE_MIME    = "audio/ogg"
+    AUDIO_MIME    = "audio/mpeg"
+    VOICE_MISSING = "[voice message]"
+    PHOTO_LABEL   = "[photo]"
+
+    def initialize(@fetch : Fetcher, @transcriber : Transcriber? = nil, @inbox : Media::Inbox? = nil)
+    end
+
+    def extract(msg : JSON::Any, typed_text : Bool) : {Array(String), Array(Bus::MediaAttachment)}
+      origin = forwarded?(msg) ? Bus::MediaAttachment::ORIGIN_FORWARDED : Bus::MediaAttachment::ORIGIN_SENDER
+      parts = [] of String
+      attachments = [] of Bus::MediaAttachment
+
+      extract_photo(msg, origin).try { |attachment| attachments << attachment }
+      extract_voice(msg, origin, typed_text, parts).try { |attachment| attachments << attachment }
+      extract_audio(msg, origin).try { |attachment| attachments << attachment }
+      extract_document(msg, origin).try { |attachment| attachments << attachment }
+
+      parts.concat(placeholders(attachments)) unless typed_text
+      {parts, attachments}
+    end
+
+    def forwarded?(msg : JSON::Any) : Bool
+      FORWARD_KEYS.any? { |key| msg[key]? }
+    end
+
+    private def extract_photo(msg : JSON::Any, origin : String) : Bus::MediaAttachment?
+      photo = msg["photo"]?.try(&.as_a?).try(&.last?)
+      return nil unless photo
+
+      bytes = fetch(photo)
+      build(Bus::MediaAttachment::TYPE_PHOTO, photo, origin, PHOTO_MIME, bytes,
+        data: bytes.try { |data| Base64.strict_encode(data) })
+    end
+
+    private def extract_voice(msg : JSON::Any, origin : String, typed_text : Bool, parts : Array(String)) : Bus::MediaAttachment?
+      voice = msg["voice"]?
+      return nil unless voice
+
+      bytes = fetch(voice)
+      mime = mime_of(voice, VOICE_MIME)
+      transcript = transcribe(bytes, mime)
+      spoken = origin == Bus::MediaAttachment::ORIGIN_SENDER && !typed_text
+
+      parts << spoken_text(transcript) if spoken
+      build(Bus::MediaAttachment::TYPE_VOICE, voice, origin, mime, bytes,
+        transcript: spoken ? nil : transcript)
+    end
+
+    private def extract_audio(msg : JSON::Any, origin : String) : Bus::MediaAttachment?
+      audio = msg["audio"]?
+      return nil unless audio
+
+      bytes = fetch(audio)
+      mime = mime_of(audio, AUDIO_MIME)
+      build(Bus::MediaAttachment::TYPE_AUDIO, audio, origin, mime, bytes,
+        transcript: transcribe(bytes, mime),
+        name: string_of(audio, "title") || string_of(audio, "file_name"))
+    end
+
+    private def extract_document(msg : JSON::Any, origin : String) : Bus::MediaAttachment?
+      document = msg["document"]?
+      return nil unless document
+
+      build(Bus::MediaAttachment::TYPE_DOCUMENT, document, origin, string_of(document, "mime_type"), fetch(document),
+        name: string_of(document, "file_name"))
+    end
+
+    private def build(type : String, node : JSON::Any, origin : String, mime : String?, bytes : Bytes?,
+                      data : String? = nil, transcript : String? = nil, name : String? = nil) : Bus::MediaAttachment
+      path = bytes.try { |content| @inbox.try(&.store(content, mime, type)) }
+      transcript_path = store_transcript(transcript, path)
+
+      Bus::MediaAttachment.new(
+        type: type,
+        url: node["file_id"].as_s,
+        file_path: path.try(&.to_s),
+        mime_type: mime,
+        size_bytes: node["file_size"]?.try(&.as_i64?),
+        data: data,
+        origin: origin,
+        transcript: transcript,
+        transcript_path: transcript_path.try(&.to_s),
+        duration_seconds: node["duration"]?.try(&.as_i?),
+        name: name,
+      )
+    end
+
+    private def store_transcript(transcript : String?, media_path : Path?) : Path?
+      return nil unless transcript && media_path
+      @inbox.try(&.store_transcript(transcript, media_path))
+    end
+
+    private def placeholders(attachments : Array(Bus::MediaAttachment)) : Array(String)
+      attachments.reject(&.spoken_instruction?).map { |attachment| placeholder(attachment) }
+    end
+
+    private def placeholder(attachment : Bus::MediaAttachment) : String
+      case attachment.type
+      when Bus::MediaAttachment::TYPE_PHOTO then PHOTO_LABEL
+      when Bus::MediaAttachment::TYPE_VOICE then VOICE_MISSING
+      when Bus::MediaAttachment::TYPE_AUDIO then "[audio: #{attachment.name || "audio"}]"
+      else                                       "[document: #{attachment.name || "unknown"}]"
+      end
+    end
+
+    private def spoken_text(transcript : String?) : String
+      transcript ? "[voice transcription]: #{transcript}" : VOICE_MISSING
+    end
+
+    private def transcribe(bytes : Bytes?, mime : String) : String?
+      transcriber = @transcriber
+      return nil unless transcriber && bytes
+      transcriber.transcribe(bytes, "audio.#{extension_for(mime)}")
+    end
+
+    private def extension_for(mime : String) : String
+      Media::Inbox.extension_for(mime, "ogg")
+    end
+
+    private def fetch(node : JSON::Any) : Bytes?
+      @fetch.call(node["file_id"].as_s)
+    end
+
+    private def mime_of(node : JSON::Any, fallback : String) : String
+      string_of(node, "mime_type") || fallback
+    end
+
+    private def string_of(node : JSON::Any, key : String) : String?
+      node[key]?.try(&.as_s?)
+    end
+  end
+end

--- a/src/autobot/channels/telegram_media.cr
+++ b/src/autobot/channels/telegram_media.cr
@@ -9,27 +9,22 @@ module Autobot::Channels
   class TelegramMedia
     alias Fetcher = Proc(String, Bytes?)
 
-    FORWARD_KEYS = %w[forward_origin forward_from forward_from_chat forward_sender_name forward_date]
-
-    PHOTO_MIME    = "image/jpeg"
-    VOICE_MIME    = "audio/ogg"
-    AUDIO_MIME    = "audio/mpeg"
+    FORWARD_KEYS  = %w[forward_origin forward_from forward_from_chat forward_sender_name forward_date]
     VOICE_MISSING = "[voice message]"
-    PHOTO_LABEL   = "[photo]"
 
     def initialize(@fetch : Fetcher, @transcriber : Transcriber? = nil, @inbox : Media::Inbox? = nil)
     end
 
     def extract(msg : JSON::Any, typed_text : Bool) : {Array(String), Array(Bus::MediaAttachment)}
-      origin = forwarded?(msg) ? Bus::MediaAttachment::ORIGIN_FORWARDED : Bus::MediaAttachment::ORIGIN_SENDER
+      forwarded = forwarded?(msg)
+      origin = forwarded ? Bus::MediaAttachment::ORIGIN_FORWARDED : Bus::MediaAttachment::ORIGIN_SENDER
+      spoken = !typed_text && !forwarded
+
+      voice, spoken_text = extract_voice(msg, origin, spoken)
+      attachments = [extract_photo(msg, origin), voice, extract_audio(msg, origin), extract_document(msg, origin)].compact
+
       parts = [] of String
-      attachments = [] of Bus::MediaAttachment
-
-      extract_photo(msg, origin).try { |attachment| attachments << attachment }
-      extract_voice(msg, origin, typed_text, parts).try { |attachment| attachments << attachment }
-      extract_audio(msg, origin).try { |attachment| attachments << attachment }
-      extract_document(msg, origin).try { |attachment| attachments << attachment }
-
+      parts << spoken_text if spoken_text
       parts.concat(placeholders(attachments)) unless typed_text
       {parts, attachments}
     end
@@ -43,22 +38,20 @@ module Autobot::Channels
       return nil unless photo
 
       bytes = fetch(photo)
-      build(Bus::MediaAttachment::TYPE_PHOTO, photo, origin, PHOTO_MIME, bytes,
+      build(Bus::MediaAttachment::TYPE_PHOTO, photo, origin, "image/jpeg", bytes,
         data: bytes.try { |data| Base64.strict_encode(data) })
     end
 
-    private def extract_voice(msg : JSON::Any, origin : String, typed_text : Bool, parts : Array(String)) : Bus::MediaAttachment?
+    private def extract_voice(msg : JSON::Any, origin : String, spoken : Bool) : {Bus::MediaAttachment?, String?}
       voice = msg["voice"]?
-      return nil unless voice
+      return {nil, nil} unless voice
 
       bytes = fetch(voice)
-      mime = mime_of(voice, VOICE_MIME)
+      mime = mime_of(voice, "audio/ogg")
       transcript = transcribe(bytes, mime)
-      spoken = origin == Bus::MediaAttachment::ORIGIN_SENDER && !typed_text
-
-      parts << spoken_text(transcript) if spoken
-      build(Bus::MediaAttachment::TYPE_VOICE, voice, origin, mime, bytes,
+      attachment = build(Bus::MediaAttachment::TYPE_VOICE, voice, origin, mime, bytes,
         transcript: spoken ? nil : transcript)
+      {attachment, spoken ? spoken_text(transcript) : nil}
     end
 
     private def extract_audio(msg : JSON::Any, origin : String) : Bus::MediaAttachment?
@@ -66,7 +59,7 @@ module Autobot::Channels
       return nil unless audio
 
       bytes = fetch(audio)
-      mime = mime_of(audio, AUDIO_MIME)
+      mime = mime_of(audio, "audio/mpeg")
       build(Bus::MediaAttachment::TYPE_AUDIO, audio, origin, mime, bytes,
         transcript: transcribe(bytes, mime),
         name: string_of(audio, "title") || string_of(audio, "file_name"))
@@ -82,8 +75,8 @@ module Autobot::Channels
 
     private def build(type : String, node : JSON::Any, origin : String, mime : String?, bytes : Bytes?,
                       data : String? = nil, transcript : String? = nil, name : String? = nil) : Bus::MediaAttachment
-      path = bytes.try { |content| @inbox.try(&.store(content, mime, type)) }
-      transcript_path = store_transcript(transcript, path)
+      path = bytes.try { |content| @inbox.try(&.store(content, mime, ".#{type}")) }
+      transcript_path = transcript && path ? @inbox.try(&.store_transcript(transcript, path)) : nil
 
       Bus::MediaAttachment.new(
         type: type,
@@ -100,18 +93,13 @@ module Autobot::Channels
       )
     end
 
-    private def store_transcript(transcript : String?, media_path : Path?) : Path?
-      return nil unless transcript && media_path
-      @inbox.try(&.store_transcript(transcript, media_path))
-    end
-
     private def placeholders(attachments : Array(Bus::MediaAttachment)) : Array(String)
-      attachments.reject(&.spoken_instruction?).map { |attachment| placeholder(attachment) }
+      attachments.reject(&.sender_voice_note?).map { |attachment| placeholder(attachment) }
     end
 
     private def placeholder(attachment : Bus::MediaAttachment) : String
       case attachment.type
-      when Bus::MediaAttachment::TYPE_PHOTO then PHOTO_LABEL
+      when Bus::MediaAttachment::TYPE_PHOTO then "[photo]"
       when Bus::MediaAttachment::TYPE_VOICE then VOICE_MISSING
       when Bus::MediaAttachment::TYPE_AUDIO then "[audio: #{attachment.name || "audio"}]"
       else                                       "[document: #{attachment.name || "unknown"}]"
@@ -125,11 +113,7 @@ module Autobot::Channels
     private def transcribe(bytes : Bytes?, mime : String) : String?
       transcriber = @transcriber
       return nil unless transcriber && bytes
-      transcriber.transcribe(bytes, "audio.#{extension_for(mime)}")
-    end
-
-    private def extension_for(mime : String) : String
-      Media::Inbox.extension_for(mime, "ogg")
+      transcriber.transcribe(bytes, "audio#{Media::Types.extension_for(mime, ".ogg")}")
     end
 
     private def fetch(node : JSON::Any) : Bytes?

--- a/src/autobot/channels/telegram_media.cr
+++ b/src/autobot/channels/telegram_media.cr
@@ -2,6 +2,7 @@ require "base64"
 require "json"
 require "../bus/events"
 require "../media/inbox"
+require "../media/types"
 require "../transcriber"
 
 module Autobot::Channels
@@ -38,7 +39,7 @@ module Autobot::Channels
       return nil unless photo
 
       bytes = fetch(photo)
-      build(Bus::MediaAttachment::TYPE_PHOTO, photo, origin, "image/jpeg", bytes,
+      build(Bus::MediaAttachment::TYPE_PHOTO, photo, origin, {".jpg", "image/jpeg"}, bytes,
         data: bytes.try { |data| Base64.strict_encode(data) })
     end
 
@@ -47,9 +48,9 @@ module Autobot::Channels
       return {nil, nil} unless voice
 
       bytes = fetch(voice)
-      mime = mime_of(voice, "audio/ogg")
-      transcript = transcribe(bytes, mime)
-      attachment = build(Bus::MediaAttachment::TYPE_VOICE, voice, origin, mime, bytes,
+      format = format_of(voice, Bus::MediaAttachment::TYPE_VOICE, "audio/ogg")
+      transcript = transcribe(bytes, format[0])
+      attachment = build(Bus::MediaAttachment::TYPE_VOICE, voice, origin, format, bytes,
         transcript: spoken ? nil : transcript)
       {attachment, spoken ? spoken_text(transcript) : nil}
     end
@@ -59,9 +60,9 @@ module Autobot::Channels
       return nil unless audio
 
       bytes = fetch(audio)
-      mime = mime_of(audio, "audio/mpeg")
-      build(Bus::MediaAttachment::TYPE_AUDIO, audio, origin, mime, bytes,
-        transcript: transcribe(bytes, mime),
+      format = format_of(audio, Bus::MediaAttachment::TYPE_AUDIO, "audio/mpeg")
+      build(Bus::MediaAttachment::TYPE_AUDIO, audio, origin, format, bytes,
+        transcript: transcribe(bytes, format[0]),
         name: string_of(audio, "title") || string_of(audio, "file_name"))
     end
 
@@ -69,13 +70,26 @@ module Autobot::Channels
       document = msg["document"]?
       return nil unless document
 
-      build(Bus::MediaAttachment::TYPE_DOCUMENT, document, origin, string_of(document, "mime_type"), fetch(document),
+      build(Bus::MediaAttachment::TYPE_DOCUMENT, document, origin,
+        format_of(document, Bus::MediaAttachment::TYPE_DOCUMENT, Media::Types::DEFAULT[1]), fetch(document),
         name: string_of(document, "file_name"))
     end
 
-    private def build(type : String, node : JSON::Any, origin : String, mime : String?, bytes : Bytes?,
+    # The platform file name is the most reliable source of the format; Telegram
+    # often omits mime_type, and Whisper rejects a mislabelled extension.
+    private def format_of(node : JSON::Any, type : String, default_mime : String) : {String, String}
+      name_extension = File.extname(string_of(node, "file_name") || "").downcase
+      mime = string_of(node, "mime_type")
+      return {name_extension, mime || Media::Types.for_extension(name_extension)[1]} unless name_extension.empty?
+
+      mime ||= default_mime
+      {Media::Types.extension_for(mime, ".#{type}"), mime}
+    end
+
+    private def build(type : String, node : JSON::Any, origin : String, format : {String, String}, bytes : Bytes?,
                       data : String? = nil, transcript : String? = nil, name : String? = nil) : Bus::MediaAttachment
-      path = bytes.try { |content| @inbox.try(&.store(content, mime, ".#{type}")) }
+      extension, mime = format
+      path = bytes.try { |content| @inbox.try(&.store(content, extension)) }
       transcript_path = transcript && path ? @inbox.try(&.store_transcript(transcript, path)) : nil
 
       Bus::MediaAttachment.new(
@@ -110,18 +124,14 @@ module Autobot::Channels
       transcript ? "[voice transcription]: #{transcript}" : VOICE_MISSING
     end
 
-    private def transcribe(bytes : Bytes?, mime : String) : String?
+    private def transcribe(bytes : Bytes?, extension : String) : String?
       transcriber = @transcriber
       return nil unless transcriber && bytes
-      transcriber.transcribe(bytes, "audio#{Media::Types.extension_for(mime, ".ogg")}")
+      transcriber.transcribe(bytes, "audio#{extension}")
     end
 
     private def fetch(node : JSON::Any) : Bytes?
       @fetch.call(node["file_id"].as_s)
-    end
-
-    private def mime_of(node : JSON::Any, fallback : String) : String
-      string_of(node, "mime_type") || fallback
     end
 
     private def string_of(node : JSON::Any, key : String) : String?

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -295,6 +295,14 @@ module Autobot::Config
     end
   end
 
+  class MediaConfig
+    include YAML::Serializable
+    property inbox : String = "inbox"
+
+    def initialize
+    end
+  end
+
   class CronConfig
     include YAML::Serializable
     property? enabled : Bool = true
@@ -380,6 +388,7 @@ module Autobot::Config
     property cron : CronConfig?
     property mcp : McpConfig?
     property plugins : PluginsConfig?
+    property media : MediaConfig?
 
     def initialize
     end
@@ -387,6 +396,11 @@ module Autobot::Config
     def workspace_path : Path
       workspace_str = agents.try(&.defaults.try(&.workspace)) || "./workspace"
       Path[workspace_str].expand(home: true)
+    end
+
+    def inbox_path : Path
+      inbox = media.try(&.inbox) || "inbox"
+      Path[inbox].expand(base: workspace_path, home: true)
     end
 
     def default_model : String

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -388,7 +388,7 @@ module Autobot::Config
     property cron : CronConfig?
     property mcp : McpConfig?
     property plugins : PluginsConfig?
-    property media : MediaConfig?
+    property media : MediaConfig = MediaConfig.new
 
     def initialize
     end
@@ -399,8 +399,7 @@ module Autobot::Config
     end
 
     def inbox_path : Path
-      inbox = media.try(&.inbox) || "inbox"
-      Path[inbox].expand(base: workspace_path, home: true)
+      Path[media.inbox].expand(base: workspace_path, home: true)
     end
 
     def default_model : String

--- a/src/autobot/media/inbox.cr
+++ b/src/autobot/media/inbox.cr
@@ -1,4 +1,5 @@
 require "random/secure"
+require "./types"
 
 module Autobot
   module Media
@@ -7,49 +8,20 @@ module Autobot
       FILE_MODE = 0o600
       ID_LENGTH =     4
 
-      EXTENSIONS = {
-        "audio/ogg"       => "ogg",
-        "audio/mpeg"      => "mp3",
-        "audio/mp4"       => "m4a",
-        "audio/x-m4a"     => "m4a",
-        "audio/wav"       => "wav",
-        "audio/webm"      => "webm",
-        "image/jpeg"      => "jpg",
-        "image/png"       => "png",
-        "image/webp"      => "webp",
-        "application/pdf" => "pdf",
-        "text/plain"      => "txt",
-      }
-
-      getter dir : Path
-
       def initialize(@dir : Path)
       end
 
-      def store(bytes : Bytes, mime_type : String?, fallback_extension : String = "bin") : Path
-        ensure_dir
-        path = @dir / "#{unique_name}.#{Inbox.extension_for(mime_type, fallback_extension)}"
-        File.write(path, bytes)
-        File.chmod(path, FILE_MODE)
+      def store(bytes : Bytes, mime_type : String?, fallback_extension : String = ".bin") : Path
+        Dir.mkdir_p(@dir, DIR_MODE)
+        path = @dir / "#{unique_name}#{Types.extension_for(mime_type, fallback_extension)}"
+        File.write(path, bytes, perm: FILE_MODE)
         path
       end
 
       def store_transcript(text : String, media_path : Path) : Path
         path = media_path.parent / "#{media_path.stem}.txt"
-        File.write(path, text)
-        File.chmod(path, FILE_MODE)
+        File.write(path, text, perm: FILE_MODE)
         path
-      end
-
-      def self.extension_for(mime_type : String?, fallback : String) : String
-        return fallback unless mime_type
-        EXTENSIONS[mime_type.split(';').first.strip.downcase]? || fallback
-      end
-
-      private def ensure_dir : Nil
-        return if Dir.exists?(@dir)
-        Dir.mkdir_p(@dir)
-        File.chmod(@dir, DIR_MODE)
       end
 
       private def unique_name : String

--- a/src/autobot/media/inbox.cr
+++ b/src/autobot/media/inbox.cr
@@ -1,0 +1,60 @@
+require "random/secure"
+
+module Autobot
+  module Media
+    class Inbox
+      DIR_MODE  = 0o700
+      FILE_MODE = 0o600
+      ID_LENGTH =     4
+
+      EXTENSIONS = {
+        "audio/ogg"       => "ogg",
+        "audio/mpeg"      => "mp3",
+        "audio/mp4"       => "m4a",
+        "audio/x-m4a"     => "m4a",
+        "audio/wav"       => "wav",
+        "audio/webm"      => "webm",
+        "image/jpeg"      => "jpg",
+        "image/png"       => "png",
+        "image/webp"      => "webp",
+        "application/pdf" => "pdf",
+        "text/plain"      => "txt",
+      }
+
+      getter dir : Path
+
+      def initialize(@dir : Path)
+      end
+
+      def store(bytes : Bytes, mime_type : String?, fallback_extension : String = "bin") : Path
+        ensure_dir
+        path = @dir / "#{unique_name}.#{Inbox.extension_for(mime_type, fallback_extension)}"
+        File.write(path, bytes)
+        File.chmod(path, FILE_MODE)
+        path
+      end
+
+      def store_transcript(text : String, media_path : Path) : Path
+        path = media_path.parent / "#{media_path.stem}.txt"
+        File.write(path, text)
+        File.chmod(path, FILE_MODE)
+        path
+      end
+
+      def self.extension_for(mime_type : String?, fallback : String) : String
+        return fallback unless mime_type
+        EXTENSIONS[mime_type.split(';').first.strip.downcase]? || fallback
+      end
+
+      private def ensure_dir : Nil
+        return if Dir.exists?(@dir)
+        Dir.mkdir_p(@dir)
+        File.chmod(@dir, DIR_MODE)
+      end
+
+      private def unique_name : String
+        "#{Time.utc.to_s("%Y%m%d-%H%M%S")}-#{Random::Secure.hex(ID_LENGTH)}"
+      end
+    end
+  end
+end

--- a/src/autobot/media/inbox.cr
+++ b/src/autobot/media/inbox.cr
@@ -1,5 +1,4 @@
 require "random/secure"
-require "./types"
 
 module Autobot
   module Media
@@ -11,9 +10,9 @@ module Autobot
       def initialize(@dir : Path)
       end
 
-      def store(bytes : Bytes, mime_type : String?, fallback_extension : String = ".bin") : Path
+      def store(bytes : Bytes, extension : String) : Path
         Dir.mkdir_p(@dir, DIR_MODE)
-        path = @dir / "#{unique_name}#{Types.extension_for(mime_type, fallback_extension)}"
+        path = @dir / "#{unique_name}#{extension}"
         File.write(path, bytes, perm: FILE_MODE)
         path
       end

--- a/src/autobot/media/types.cr
+++ b/src/autobot/media/types.cr
@@ -1,0 +1,37 @@
+module Autobot
+  module Media
+    module Types
+      DEFAULT = {"document", "application/octet-stream"}
+
+      BY_EXTENSION = {
+        ".jpg"  => {"photo", "image/jpeg"},
+        ".jpeg" => {"photo", "image/jpeg"},
+        ".png"  => {"photo", "image/png"},
+        ".webp" => {"photo", "image/webp"},
+        ".bmp"  => {"photo", "image/bmp"},
+        ".gif"  => {"animation", "image/gif"},
+        ".mp4"  => {"video", "video/mp4"},
+        ".pdf"  => {"document", "application/pdf"},
+        ".txt"  => {"document", "text/plain"},
+        ".ogg"  => {"voice", "audio/ogg"},
+        ".mp3"  => {"audio", "audio/mpeg"},
+        ".m4a"  => {"audio", "audio/mp4"},
+        ".wav"  => {"audio", "audio/wav"},
+        ".webm" => {"audio", "audio/webm"},
+      }
+
+      EXTENSION_BY_MIME = BY_EXTENSION
+        .each_with_object({} of String => String) { |(ext, (_, mime)), map| map[mime] ||= ext }
+        .merge({"audio/x-m4a" => ".m4a"})
+
+      def self.for_extension(extension : String) : {String, String}
+        BY_EXTENSION[extension.downcase]? || DEFAULT
+      end
+
+      def self.extension_for(mime_type : String?, fallback : String) : String
+        return fallback unless mime_type
+        EXTENSION_BY_MIME[mime_type.split(';').first.strip.downcase]? || fallback
+      end
+    end
+  end
+end

--- a/src/autobot/tools/message.cr
+++ b/src/autobot/tools/message.cr
@@ -1,4 +1,5 @@
 require "../bus/events"
+require "../media/types"
 require "./result"
 require "./sandbox_executor"
 
@@ -17,20 +18,6 @@ module Autobot
     # media (images, GIFs, documents) from the workspace.
     class MessageTool < Tool
       Log = ::Log.for("tools.message")
-
-      MEDIA_TYPES = {
-        ".jpg"  => {"photo", "image/jpeg"},
-        ".jpeg" => {"photo", "image/jpeg"},
-        ".png"  => {"photo", "image/png"},
-        ".webp" => {"photo", "image/webp"},
-        ".bmp"  => {"photo", "image/bmp"},
-        ".gif"  => {"animation", "image/gif"},
-        ".mp4"  => {"video", "video/mp4"},
-        ".pdf"  => {"document", "application/pdf"},
-        ".ogg"  => {"voice", "audio/ogg"},
-        ".mp3"  => {"audio", "audio/mpeg"},
-        ".wav"  => {"audio", "audio/wav"},
-      }
 
       @send_callback : SendCallback?
       @default_channel : String
@@ -130,8 +117,7 @@ module Autobot
         result = executor.read_file_base64(file_path)
         return ToolResult.error("Cannot read file: #{result.content}") unless result.success?
 
-        ext = File.extname(file_path).downcase
-        media_type, mime_type = MEDIA_TYPES[ext]? || {"document", "application/octet-stream"}
+        media_type, mime_type = Media::Types.for_extension(File.extname(file_path))
 
         Log.info { "Attaching file: #{file_path} (#{media_type}, #{mime_type})" }
 


### PR DESCRIPTION
## Overview

- [x] a voice note the sender recorded in the chat is transcribed into the message text as before; audio files, photos, documents and anything forwarded become attachments that never enter the message text
- [x] transcripts of content attachments live on the attachment (`transcript`, `transcript_path`), not in `content`
- [x] incoming media files are saved under `<workspace>/inbox`, configurable via `media.inbox`, so tools can read them by path
- [x] `MediaAttachment` gains `origin`, `transcript`, `transcript_path`, `duration_seconds` and `name`, with `sender_voice_note?`
- [x] Telegram media handling extracted into `TelegramMedia`; forwards detected via `forward_origin` and the legacy forward fields
- [x] media is downloaded and transcribed only after the group mention and allowlist checks pass; the group chat log records typed text or a `[media]` label
- [x] one extension and mime table (`Media::Types`) shared by the inbox and the `message` tool, so inbox files go back out with the right type (`.m4a`, `.webm`, `.txt` added)
- [x] specs for the classifier, the inbox, the media types, the attachment model, config and the channel wiring; docs for media, configuration and Telegram