### PR TITLE
feat(tools): per-bot tool allowlist and filesystem roots

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,7 +141,7 @@ When sandboxed, all shell commands run inside the sandbox (bubblewrap or Docker)
 
 ### Tool Allowlist
 
-`tools.enabled` names the tools a bot may have. Anything not listed is never registered, whichever source it comes from: built-in tools, skill scripts, plugins and MCP servers all pass through the same check. A name ending in `*` matches by prefix, as in the MCP `tools:` list. Leave it out to keep today's behaviour of registering everything. `autobot doctor` prints the effective list.
+`tools.enabled` names the tools a bot may have. Anything not listed is never registered, whichever source it comes from: built-in tools, skill scripts, plugins and MCP servers all pass through the same check. A name ending in `*` matches by prefix, as in the MCP `tools:` list. Leave it out to keep today's behaviour of registering everything. `autobot doctor` prints the effective list and warns about an entry that matches no known tool, so a typo does not silently remove a tool; at startup the bot logs a warning for entries that matched nothing.
 
 ### Filesystem Roots
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,15 @@ channels:
 
 ```yaml
 tools:
+  enabled:       # Optional allowlist; omit to register every tool
+    - read_file
+    - write_file
+    - edit_file
+    - list_dir
+    - message
+    - "ha_*"     # patterns ending in * match by prefix (skills, plugins, MCP tools)
+  filesystem:
+    roots: [notes, inbox]  # Optional; file tools may only touch these workspace subdirectories
   sandbox: auto  # auto | bubblewrap | docker | none (default: auto)
   docker_image: "python:3.14-alpine"  # optional, default: alpine:latest
   sandbox_env:   # env vars to forward into Docker sandbox (default: none)
@@ -129,6 +138,14 @@ tools:
 ```
 
 When sandboxed, all shell commands run inside the sandbox (bubblewrap or Docker). The kernel enforces workspace restrictions — pipes, redirects, and other shell features are safe to use because the process cannot access files outside the workspace regardless.
+
+### Tool Allowlist
+
+`tools.enabled` names the tools a bot may have. Anything not listed is never registered, whichever source it comes from: built-in tools, skill scripts, plugins and MCP servers all pass through the same check. A name ending in `*` matches by prefix, as in the MCP `tools:` list. Leave it out to keep today's behaviour of registering everything. `autobot doctor` prints the effective list.
+
+### Filesystem Roots
+
+`tools.filesystem.roots` limits `read_file`, `write_file`, `edit_file` and `list_dir` to the listed workspace subdirectories. Paths resolve relative to the workspace and `..` cannot escape a root. Commands run by `exec` are not affected; they stay bound to the workspace by the sandbox.
 
 ### Safety Guard Overrides
 
@@ -289,7 +306,9 @@ tools:
     # provider: openai       # optional override (openai or gemini)
     # model: gpt-image-1     # optional, auto-detected from provider
     # size: 1024x1024
-  restrict_to_workspace: true  # Default: true (recommended for security)
+  enabled: [read_file, write_file, edit_file, list_dir, message]  # optional allowlist
+  filesystem:
+    roots: [notes, inbox]      # optional, workspace subdirectories the file tools may touch
 
 # Cron scheduler
 cron:

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -133,6 +133,18 @@ tools:
 - `docker_image` — Docker image to use for sandbox containers. Overrides `Dockerfile.sandbox` when set. Only applies when sandbox is `docker` or `auto` resolves to Docker.
 - `sandbox_env` — List of environment variable names to forward into Docker containers. Only listed variables are forwarded — empty by default for security. Useful when sandbox scripts need access to specific env vars (e.g. `HA_URL`, `MQTT_HOST`).
 
+### Filesystem roots
+
+Independently of the sandbox backend, `tools.filesystem.roots` narrows the file tools to workspace subdirectories:
+
+```yaml
+tools:
+  filesystem:
+    roots: [notes, inbox]
+```
+
+The check runs in the executor before any sandboxed or direct operation, so it applies in every sandbox mode including `none`. Relative paths resolve against the workspace, `..` is normalized before the check, and a path outside every root returns a tool error naming the allowed directories. The `exec` tool is not narrowed by roots; the sandbox keeps it inside the workspace.
+
 ### Custom sandbox image (Dockerfile.sandbox)
 
 When using Docker sandbox, the default `alpine:latest` image only includes basic shell tools. To add runtimes your bot needs (Python, SQLite, GitHub CLI, etc.), create a `Dockerfile.sandbox` in your bot folder:

--- a/docs/security.md
+++ b/docs/security.md
@@ -153,6 +153,7 @@ autobot doctor --strict # Fail on any warning (CI/CD)
 **⚠️ Warnings (review recommended):**
 
 - Filesystem root configured outside the workspace
+- `tools.enabled` entry that matches no known tool
 - Gateway bound to 0.0.0.0 (network exposure)
 - Channel authorization not configured (empty `allow_from`)
 - Missing `.env` file

--- a/docs/security.md
+++ b/docs/security.md
@@ -152,6 +152,7 @@ autobot doctor --strict # Fail on any warning (CI/CD)
 
 **⚠️ Warnings (review recommended):**
 
+- Filesystem root configured outside the workspace
 - Gateway bound to 0.0.0.0 (network exposure)
 - Channel authorization not configured (empty `allow_from`)
 - Missing `.env` file
@@ -270,7 +271,22 @@ so that the worst outcome is a bad note rather than an action.
 
 ---
 
-## 12. Known Limitations
+## 12. Least Tools Per Bot
+
+A bot that reads other people's content should not be able to do much with it. Two settings make that a property of the config rather than of the prompt:
+
+```yaml
+tools:
+  enabled: [read_file, write_file, edit_file, list_dir, message]
+  filesystem:
+    roots: [notes, inbox]
+```
+
+`tools.enabled` is an allowlist applied at registration, so a tool that is not listed does not exist for the model, whether it is built in, a skill script, a plugin or an MCP tool. `tools.filesystem.roots` keeps the file tools inside the listed workspace subdirectories. With both in place, the worst a planted instruction inside an attachment can do is write a bad note. `autobot doctor` prints the effective tool list and reminds you to set the allowlist when it is missing.
+
+---
+
+## 13. Known Limitations
 
 **WhatsApp Bridge:** WebSocket connection has no authentication (ws://).
 

--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -553,7 +553,65 @@ describe Autobot::CLI::Doctor do
         Autobot::CLI::Doctor.check_tools(config, 0)
 
         io.to_s.should contain("✓ Tools limited to: read_file, write_file")
-        io.to_s.should contain("Patterns for skills, plugins or MCP tools: ha_*")
+        io.to_s.should contain("match no known tool: ha_*")
+      end
+    end
+
+    it "warns about an allowlist entry that matches no known tool" do
+      config = make_config(<<-YAML
+      tools:
+        enabled: [read_flie, write_file]
+      YAML
+      )
+
+      with_doctor_io do |io|
+        warnings = Autobot::CLI::Doctor.check_tools(config, 0)
+
+        warnings.should eq(1)
+        io.to_s.should contain("! tools.enabled entries match no known tool: read_flie")
+      end
+    end
+
+    it "accepts skill scripts, plugin tools and listed MCP tools as known" do
+      workspace = TestHelper.tmp_dir("doctor-skills")
+      Dir.mkdir_p(workspace / "skills")
+      File.write(workspace / "skills" / "deploy.sh", "#!/bin/sh")
+      config = make_config(<<-YAML
+      agents:
+        defaults:
+          workspace: "#{workspace}"
+      tools:
+        enabled: [bash_deploy, get_weather, ha_get_*, read_file]
+      mcp:
+        servers:
+          homeassistant:
+            command: uvx
+            tools: [ha_get_state, ha_call_service]
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_tools(config, 0).should eq(0)
+        io.to_s.should_not contain("match no known tool")
+      end
+    ensure
+      FileUtils.rm_rf(workspace) if workspace
+    end
+
+    it "does not warn when an MCP server has no tool list" do
+      config = make_config(<<-YAML
+      tools:
+        enabled: [read_file, something_remote]
+      mcp:
+        servers:
+          remote:
+            command: uvx
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_tools(config, 0).should eq(0)
+        io.to_s.should contain("Unverified tools.enabled entries: something_remote")
       end
     end
 

--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -531,6 +531,67 @@ describe Autobot::CLI::Doctor do
     end
   end
 
+  describe ".check_tools" do
+    it "reports all tools with a hint when no allowlist is set" do
+      with_doctor_io do |io|
+        warnings = Autobot::CLI::Doctor.check_tools(make_config("{}"), 0)
+
+        warnings.should eq(0)
+        io.to_s.should contain("✓ Tools: all built-in tools")
+        io.to_s.should contain("Set tools.enabled")
+      end
+    end
+
+    it "lists the effective built-in tools and the remaining patterns" do
+      config = make_config(<<-YAML
+      tools:
+        enabled: [read_file, write_file, ha_*]
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_tools(config, 0)
+
+        io.to_s.should contain("✓ Tools limited to: read_file, write_file")
+        io.to_s.should contain("Patterns for skills, plugins or MCP tools: ha_*")
+      end
+    end
+
+    it "passes roots inside the workspace and warns about roots outside it" do
+      config = make_config(<<-YAML
+      agents:
+        defaults:
+          workspace: /srv/bot/workspace
+      tools:
+        filesystem:
+          roots: [notes, ../outside]
+      YAML
+      )
+
+      with_doctor_io do |io|
+        warnings = Autobot::CLI::Doctor.check_tools(config, 0)
+
+        warnings.should eq(1)
+        io.to_s.should contain("! Filesystem root outside the workspace: ../outside")
+      end
+
+      inside = make_config(<<-YAML
+      agents:
+        defaults:
+          workspace: /srv/bot/workspace
+      tools:
+        filesystem:
+          roots: [notes, inbox]
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_tools(inside, 0).should eq(0)
+        io.to_s.should contain("✓ Filesystem tools limited to: notes, inbox")
+      end
+    end
+  end
+
   describe ".check_web_search" do
     it "skips when no tools configured" do
       config = make_config("{}")

--- a/spec/autobot/cli/setup_helper_spec.cr
+++ b/spec/autobot/cli/setup_helper_spec.cr
@@ -90,6 +90,31 @@ describe Autobot::CLI::SetupHelper do
       tool_registry.size.should be > 0
     end
 
+    it "registers only the tools listed in tools.enabled" do
+      workspace = TestHelper.tmp_dir("notes-bot")
+      config = Autobot::Config::Config.from_yaml(<<-YAML
+      agents:
+        defaults:
+          workspace: "#{workspace}"
+      providers:
+        anthropic:
+          api_key: "sk-test"
+      tools:
+        sandbox: "none"
+        enabled: [read_file, write_file, edit_file, list_dir]
+        filesystem:
+          roots: [notes, inbox]
+      YAML
+      )
+
+      tool_registry, _mcp_clients = Autobot::CLI::SetupHelper.setup_tools(config)
+
+      tool_registry.tool_names.sort.should eq(["edit_file", "list_dir", "read_file", "write_file"])
+      tool_registry.sandbox_executor.try(&.roots).should eq([workspace / "notes", workspace / "inbox"])
+    ensure
+      FileUtils.rm_rf(workspace) if workspace
+    end
+
     it "registers expected tools" do
       config = SetupHelperSpecHelper.create_test_config
 

--- a/spec/autobot/config/schema_spec.cr
+++ b/spec/autobot/config/schema_spec.cr
@@ -168,6 +168,25 @@ describe Autobot::Config::Config do
       config.tools.try(&.exec.try(&.timeout)).should eq(120)
       config.tools.try(&.sandbox).should eq("bubblewrap")
     end
+
+    it "parses the tool allowlist and filesystem roots" do
+      yaml = <<-YAML
+      tools:
+        enabled: [read_file, "ha_*"]
+        filesystem:
+          roots: [notes, inbox]
+      YAML
+
+      config = Autobot::Config::Config.from_yaml(yaml)
+      config.tools.try(&.enabled).should eq(["read_file", "ha_*"])
+      config.tools.try(&.filesystem.try(&.roots)).should eq(["notes", "inbox"])
+    end
+
+    it "defaults to all tools and the whole workspace" do
+      config = Autobot::Config::Config.from_yaml("tools:\n  sandbox: none\n")
+      config.tools.try(&.enabled).should eq([] of String)
+      config.tools.try(&.filesystem).should be_nil
+    end
   end
 
   describe "#workspace_path" do

--- a/spec/autobot/tools/allowlist_spec.cr
+++ b/spec/autobot/tools/allowlist_spec.cr
@@ -1,0 +1,19 @@
+require "../../spec_helper"
+
+describe Autobot::Tools::Allowlist do
+  it "allows everything when empty" do
+    list = Autobot::Tools::Allowlist.all
+    list.restricted?.should be_false
+    list.allows?("anything").should be_true
+  end
+
+  it "matches exact names and prefix patterns only" do
+    list = Autobot::Tools::Allowlist.new(["read_file", "ha_*"])
+
+    list.restricted?.should be_true
+    list.allows?("read_file").should be_true
+    list.allows?("ha_get_state").should be_true
+    list.allows?("write_file").should be_false
+    list.allows?("read_file_extra").should be_false
+  end
+end

--- a/spec/autobot/tools/allowlist_spec.cr
+++ b/spec/autobot/tools/allowlist_spec.cr
@@ -7,6 +7,12 @@ describe Autobot::Tools::Allowlist do
     list.allows?("anything").should be_true
   end
 
+  it "reports which pattern matched" do
+    list = Autobot::Tools::Allowlist.new(["read_file", "ha_*"])
+    list.matching_pattern("ha_get_state").should eq("ha_*")
+    list.matching_pattern("exec").should be_nil
+  end
+
   it "matches exact names and prefix patterns only" do
     list = Autobot::Tools::Allowlist.new(["read_file", "ha_*"])
 

--- a/spec/autobot/tools/filesystem_roots_spec.cr
+++ b/spec/autobot/tools/filesystem_roots_spec.cr
@@ -1,0 +1,62 @@
+require "../../spec_helper"
+
+private def with_roots(&)
+  workspace = TestHelper.tmp_dir("roots")
+  Dir.mkdir_p(workspace / "notes")
+  Dir.mkdir_p(workspace / "inbox")
+  Dir.mkdir_p(workspace / "memory")
+  File.write(workspace / "notes" / "a.md", "note")
+  File.write(workspace / "memory" / "MEMORY.md", "secret")
+  roots = Autobot::Tools.resolve_roots(["notes", "inbox"], workspace)
+  yield Autobot::Tools::SandboxExecutor.new(workspace, false, roots), workspace
+ensure
+  FileUtils.rm_rf(workspace) if workspace
+end
+
+describe Autobot::Tools::SandboxExecutor do
+  describe "filesystem roots" do
+    it "allows reads, writes and listings inside a root" do
+      with_roots do |executor, workspace|
+        executor.read_file((workspace / "notes" / "a.md").to_s).content.should eq("note")
+        executor.write_file((workspace / "inbox" / "b.txt").to_s, "x").success?.should be_true
+        executor.list_dir((workspace / "notes").to_s).success?.should be_true
+      end
+    end
+
+    it "checks relative paths against the workspace" do
+      with_roots do |executor, _|
+        executor.read_file("memory/MEMORY.md").content.should contain("outside the allowed directories")
+        executor.read_file("notes/a.md").content.should_not contain("outside the allowed directories")
+      end
+    end
+
+    it "refuses paths outside every root, including traversal" do
+      with_roots do |executor, workspace|
+        result = executor.read_file((workspace / "memory" / "MEMORY.md").to_s)
+        result.success?.should be_false
+        result.content.should contain("outside the allowed directories (notes, inbox)")
+
+        executor.read_file("notes/../memory/MEMORY.md").success?.should be_false
+        executor.write_file((workspace / "SOUL.md").to_s, "x").success?.should be_false
+        executor.list_dir(workspace.to_s).success?.should be_false
+        executor.read_file_base64("/etc/hosts").success?.should be_false
+      end
+    end
+
+    it "does not restrict commands" do
+      with_roots do |executor, _|
+        executor.exec("echo ok").content.strip.should eq("ok")
+      end
+    end
+
+    it "keeps everything open without roots" do
+      workspace = TestHelper.tmp_dir("noroots")
+      begin
+        File.write(workspace / "x.txt", "x")
+        Autobot::Tools::SandboxExecutor.new(workspace, false).read_file((workspace / "x.txt").to_s).success?.should be_true
+      ensure
+        FileUtils.rm_rf(workspace)
+      end
+    end
+  end
+end

--- a/spec/autobot/tools/registry_spec.cr
+++ b/spec/autobot/tools/registry_spec.cr
@@ -69,6 +69,16 @@ describe Autobot::Tools::Registry do
     registry.get("unknown").should be_nil
   end
 
+  it "registers only tools the allowlist permits" do
+    registry = Autobot::Tools::Registry.new(allowlist: Autobot::Tools::Allowlist.new(["other"]))
+    registry.register(DummyTool.new)
+    registry.has?("dummy").should be_false
+
+    permitted = Autobot::Tools::Registry.new(allowlist: Autobot::Tools::Allowlist.new(["dum*"]))
+    permitted.register(DummyTool.new)
+    permitted.has?("dummy").should be_true
+  end
+
   it "unregisters a tool" do
     registry = Autobot::Tools::Registry.new
     registry.register(DummyTool.new)

--- a/spec/autobot/tools/registry_spec.cr
+++ b/spec/autobot/tools/registry_spec.cr
@@ -79,6 +79,13 @@ describe Autobot::Tools::Registry do
     permitted.has?("dummy").should be_true
   end
 
+  it "reports allowlist entries that never matched a tool" do
+    registry = Autobot::Tools::Registry.new(allowlist: Autobot::Tools::Allowlist.new(["dummy", "read_flie"]))
+    registry.register(DummyTool.new)
+    registry.unmatched_patterns.should eq(["read_flie"])
+    Autobot::Tools::Registry.new.unmatched_patterns.should be_empty
+  end
+
   it "unregisters a tool" do
     registry = Autobot::Tools::Registry.new
     registry.register(DummyTool.new)

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -66,6 +66,8 @@ module Autobot::Agent
       exec_allow_patterns : Array(Regex) = [] of Regex,
       sandbox_config : String = "auto",
       rate_limiter : Tools::RateLimiter? = nil,
+      enabled_tools : Array(String) = [] of String,
+      filesystem_roots : Array(String) = [] of String,
     )
       @model = model || @provider.default_model
       sandboxed = sandbox_config.downcase != "none"
@@ -86,7 +88,7 @@ module Autobot::Agent
         sessions: @sessions
       )
 
-      register_optional_tools(brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns, sandbox_config, rate_limiter)
+      register_optional_tools(brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns, sandbox_config, rate_limiter, enabled_tools, filesystem_roots)
       cache_tool_references
     end
 
@@ -293,6 +295,8 @@ module Autobot::Agent
       exec_allow_patterns : Array(Regex),
       sandbox_config : String,
       rate_limiter : Tools::RateLimiter?,
+      enabled_tools : Array(String),
+      filesystem_roots : Array(String),
     ) : Nil
       subagents = SubagentManager.new(
         provider: @provider,
@@ -304,7 +308,9 @@ module Autobot::Agent
         exec_deny_patterns: exec_deny_patterns,
         exec_allow_patterns: exec_allow_patterns,
         sandbox_config: sandbox_config,
-        rate_limiter: rate_limiter
+        rate_limiter: rate_limiter,
+        enabled_tools: enabled_tools,
+        filesystem_roots: filesystem_roots,
       )
       @tools.register(Tools::SpawnTool.new(subagents))
 

--- a/src/autobot/agent/subagent.cr
+++ b/src/autobot/agent/subagent.cr
@@ -55,6 +55,8 @@ module Autobot
         @exec_allow_patterns : Array(Regex) = [] of Regex,
         @sandbox_config : String = "auto",
         @rate_limiter : Tools::RateLimiter? = nil,
+        @enabled_tools : Array(String) = [] of String,
+        @filesystem_roots : Array(String) = [] of String,
       )
         @context = Context::Builder.new(@workspace)
       end
@@ -120,6 +122,8 @@ module Autobot
             sandbox_config: @sandbox_config,
             brave_api_key: @brave_api_key,
             rate_limiter: @rate_limiter,
+            enabled_tools: @enabled_tools,
+            filesystem_roots: @filesystem_roots,
           )
 
           executor = ToolExecutor.new(

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -171,21 +171,56 @@ module Autobot
       end
 
       BUILTIN_TOOLS = %w[read_file write_file edit_file list_dir exec web_search web_fetch message spawn cron generate_image]
+      PLUGIN_TOOLS  = %w[sqlite github get_weather get_recent_chat_log text_to_speech get_system_info]
 
       def self.check_tools(config : Config::Config, warnings : Int32) : Int32
         allowlist = Tools::Allowlist.new(config.tools.try(&.enabled) || [] of String)
 
-        if allowlist.restricted?
-          builtin = BUILTIN_TOOLS.select { |name| allowlist.allows?(name) }
-          report(Status::Pass, "Tools limited to: #{builtin.empty? ? "none of the built-in tools" : builtin.join(", ")}")
-          extra = allowlist.patterns.reject { |pattern| BUILTIN_TOOLS.any? { |name| Tools::Allowlist.new([pattern]).allows?(name) } }
-          hint("Patterns for skills, plugins or MCP tools: #{extra.join(", ")}") unless extra.empty?
-        else
+        unless allowlist.restricted?
           report(Status::Pass, "Tools: all built-in tools, plus skills, plugins and MCP servers")
           hint("Set tools.enabled to limit this bot to the tools it needs")
+          return check_filesystem_roots(config, warnings)
         end
 
+        builtin = BUILTIN_TOOLS.select { |name| allowlist.allows?(name) }
+        report(Status::Pass, "Tools limited to: #{builtin.empty? ? "none of the built-in tools" : builtin.join(", ")}")
+        warnings = check_unknown_tools(config, allowlist, warnings)
         check_filesystem_roots(config, warnings)
+      end
+
+      def self.check_unknown_tools(config : Config::Config, allowlist : Tools::Allowlist, warnings : Int32) : Int32
+        known = BUILTIN_TOOLS + PLUGIN_TOOLS + skill_tool_names(config) + mcp_tool_patterns(config)
+        unknown = allowlist.patterns.reject { |pattern| known.any? { |candidate| overlap?(pattern, candidate) } }
+        return warnings if unknown.empty?
+
+        if mcp_servers_without_tool_list?(config)
+          report(Status::Pass, "Unverified tools.enabled entries: #{unknown.join(", ")}")
+          hint("An MCP server without a tools list may provide them; a typo here silently disables the tool")
+          return warnings
+        end
+
+        report(Status::Warn, "tools.enabled entries match no known tool: #{unknown.join(", ")}")
+        hint("Check the spelling; a tool that matches nothing is silently missing from the bot")
+        warnings + 1
+      end
+
+      private def self.skill_tool_names(config : Config::Config) : Array(String)
+        [config.workspace_path / "skills", Config::Loader.skills_dir].flat_map do |dir|
+          next [] of String unless Dir.exists?(dir)
+          Dir.children(dir).select(&.ends_with?(".sh")).map { |file| "bash_#{file.rchop(".sh")}" }
+        end
+      end
+
+      private def self.mcp_tool_patterns(config : Config::Config) : Array(String)
+        config.mcp.try(&.servers.values.flat_map(&.tools)) || [] of String
+      end
+
+      private def self.mcp_servers_without_tool_list?(config : Config::Config) : Bool
+        config.mcp.try(&.servers.values.any?(&.tools.empty?)) || false
+      end
+
+      private def self.overlap?(pattern : String, candidate : String) : Bool
+        Tools::Allowlist.matches?(pattern, candidate.rchop("*")) || Tools::Allowlist.matches?(candidate, pattern.rchop("*"))
       end
 
       def self.check_filesystem_roots(config : Config::Config, warnings : Int32) : Int32

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -74,6 +74,9 @@ module Autobot
         # Security settings
         errors = check_security_settings(config, errors)
 
+        # Tools
+        warnings = check_tools(config, warnings)
+
         # Workspace
         errors, warnings = check_workspace(config, config_file, errors, warnings)
 
@@ -165,6 +168,44 @@ module Autobot
         errors = check_sandbox_availability(config, errors)
 
         errors
+      end
+
+      BUILTIN_TOOLS = %w[read_file write_file edit_file list_dir exec web_search web_fetch message spawn cron generate_image]
+
+      def self.check_tools(config : Config::Config, warnings : Int32) : Int32
+        allowlist = Tools::Allowlist.new(config.tools.try(&.enabled) || [] of String)
+
+        if allowlist.restricted?
+          builtin = BUILTIN_TOOLS.select { |name| allowlist.allows?(name) }
+          report(Status::Pass, "Tools limited to: #{builtin.empty? ? "none of the built-in tools" : builtin.join(", ")}")
+          extra = allowlist.patterns.reject { |pattern| BUILTIN_TOOLS.any? { |name| Tools::Allowlist.new([pattern]).allows?(name) } }
+          hint("Patterns for skills, plugins or MCP tools: #{extra.join(", ")}") unless extra.empty?
+        else
+          report(Status::Pass, "Tools: all built-in tools, plus skills, plugins and MCP servers")
+          hint("Set tools.enabled to limit this bot to the tools it needs")
+        end
+
+        check_filesystem_roots(config, warnings)
+      end
+
+      def self.check_filesystem_roots(config : Config::Config, warnings : Int32) : Int32
+        roots = config.tools.try(&.filesystem.try(&.roots)) || [] of String
+        return warnings if roots.empty?
+
+        workspace = config.workspace_path
+        outside = roots.reject do |root|
+          resolved = Path[root].expand(base: workspace, home: true)
+          resolved == workspace || resolved.to_s.starts_with?("#{workspace}/")
+        end
+
+        if outside.empty?
+          report(Status::Pass, "Filesystem tools limited to: #{roots.join(", ")}")
+          return warnings
+        end
+
+        report(Status::Warn, "Filesystem root outside the workspace: #{outside.join(", ")}")
+        hint("Roots are resolved relative to the workspace and must stay inside it")
+        warnings + 1
       end
 
       def self.check_sandbox_availability(config : Config::Config, errors : Int32) : Int32

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -159,7 +159,9 @@ module Autobot
           exec_deny_patterns: deny_patterns,
           exec_allow_patterns: allow_patterns,
           sandbox_config: sandbox_config,
-          rate_limiter: rate_limiter
+          rate_limiter: rate_limiter,
+          enabled_tools: config.tools.try(&.enabled) || [] of String,
+          filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
         )
       end
 

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -114,7 +114,9 @@ module Autobot
             (config.workspace_path / "skills").to_s,
             (Config::Loader.skills_dir).to_s,
           ],
-          rate_limiter: rate_limiter
+          rate_limiter: rate_limiter,
+          enabled_tools: config.tools.try(&.enabled) || [] of String,
+          filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
         )
 
         register_image_tool(config, tool_registry)

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -281,8 +281,18 @@ module Autobot::Config
     end
   end
 
+  class FilesystemToolsConfig
+    include YAML::Serializable
+    property roots : Array(String) = [] of String
+
+    def initialize
+    end
+  end
+
   class ToolsConfig
     include YAML::Serializable
+    property enabled : Array(String) = [] of String
+    property filesystem : FilesystemToolsConfig?
     property web : WebToolsConfig?
     property exec : ExecToolConfig?
     property image : ImageConfig?

--- a/src/autobot/mcp/setup.cr
+++ b/src/autobot/mcp/setup.cr
@@ -140,15 +140,7 @@ module Autobot
     # Empty allowlist means all tools are allowed.
     # Patterns ending with `*` match as prefixes.
     def self.tool_allowed?(name : String, allowlist : Array(String)) : Bool
-      return true if allowlist.empty?
-
-      allowlist.any? do |pattern|
-        if pattern.ends_with?("*")
-          name.starts_with?(pattern.rchop("*"))
-        else
-          name == pattern
-        end
-      end
+      Tools::Allowlist.new(allowlist).allows?(name)
     end
   end
 end

--- a/src/autobot/tools/allowlist.cr
+++ b/src/autobot/tools/allowlist.cr
@@ -15,11 +15,15 @@ module Autobot::Tools
     end
 
     def allows?(name : String) : Bool
-      return true unless restricted?
+      !restricted? || !matching_pattern(name).nil?
+    end
 
-      @patterns.any? do |pattern|
-        pattern.ends_with?("*") ? name.starts_with?(pattern.rchop("*")) : name == pattern
-      end
+    def matching_pattern(name : String) : String?
+      @patterns.find { |pattern| Allowlist.matches?(pattern, name) }
+    end
+
+    def self.matches?(pattern : String, name : String) : Bool
+      pattern.ends_with?("*") ? name.starts_with?(pattern.rchop("*")) : name == pattern
     end
   end
 end

--- a/src/autobot/tools/allowlist.cr
+++ b/src/autobot/tools/allowlist.cr
@@ -1,0 +1,25 @@
+module Autobot::Tools
+  # Empty patterns allow everything; a pattern ending in `*` matches by prefix.
+  struct Allowlist
+    getter patterns : Array(String)
+
+    def self.all : Allowlist
+      new([] of String)
+    end
+
+    def initialize(@patterns : Array(String))
+    end
+
+    def restricted? : Bool
+      !@patterns.empty?
+    end
+
+    def allows?(name : String) : Bool
+      return true unless restricted?
+
+      @patterns.any? do |pattern|
+        pattern.ends_with?("*") ? name.starts_with?(pattern.rchop("*")) : name == pattern
+      end
+    end
+  end
+end

--- a/src/autobot/tools/registry.cr
+++ b/src/autobot/tools/registry.cr
@@ -14,6 +14,8 @@ module Autobot::Tools
     @sandbox_executor : SandboxExecutor?
 
     getter allowlist : Allowlist
+    @matched_patterns = Set(String).new
+    @warned_unmatched = false
 
     def initialize(@session_key : String = "default", rate_limiter : RateLimiter? = nil, @allowlist : Allowlist = Allowlist.all)
       @tools = {} of String => Tool
@@ -22,11 +24,19 @@ module Autobot::Tools
     end
 
     def register(tool : Tool) : Nil
-      unless @allowlist.allows?(tool.name)
-        Log.info { "Tool not registered (not in tools.enabled): #{tool.name}" }
-        return
+      if @allowlist.restricted?
+        pattern = @allowlist.matching_pattern(tool.name)
+        unless pattern
+          Log.info { "Tool not registered (not in tools.enabled): #{tool.name}" }
+          return
+        end
+        @matched_patterns << pattern
       end
       @tools[tool.name] = tool
+    end
+
+    def unmatched_patterns : Array(String)
+      @allowlist.patterns.reject { |pattern| @matched_patterns.includes?(pattern) }
     end
 
     # Unregister a tool by name
@@ -55,6 +65,7 @@ module Autobot::Tools
       exclude : Array(String)? = nil,
       compact : Array(String)? = nil,
     ) : Array(Hash(String, JSON::Any))
+      warn_unmatched_once
       tools = @tools.values
       tools = tools.reject { |tool| exclude.try(&.includes?(tool.name)) } if exclude
 
@@ -65,6 +76,15 @@ module Autobot::Tools
           tool.to_schema
         end
       end
+    end
+
+    private def warn_unmatched_once : Nil
+      return if @warned_unmatched
+      @warned_unmatched = true
+
+      unmatched = unmatched_patterns
+      return if unmatched.empty?
+      Log.warn { "tools.enabled entries matched no tool: #{unmatched.join(", ")}" }
     end
 
     def execute(name : String, params : Hash(String, JSON::Any), session_key : String? = nil) : String

--- a/src/autobot/tools/registry.cr
+++ b/src/autobot/tools/registry.cr
@@ -1,3 +1,4 @@
+require "./allowlist"
 require "./base"
 require "./rate_limiter"
 require "./sandbox_executor"
@@ -12,14 +13,19 @@ module Autobot::Tools
     @session_key : String
     @sandbox_executor : SandboxExecutor?
 
-    def initialize(@session_key : String = "default", rate_limiter : RateLimiter? = nil)
+    getter allowlist : Allowlist
+
+    def initialize(@session_key : String = "default", rate_limiter : RateLimiter? = nil, @allowlist : Allowlist = Allowlist.all)
       @tools = {} of String => Tool
       @rate_limiter = rate_limiter || RateLimiter.new
       @sandbox_executor = nil
     end
 
-    # Register a tool
     def register(tool : Tool) : Nil
+      unless @allowlist.allows?(tool.name)
+        Log.info { "Tool not registered (not in tools.enabled): #{tool.name}" }
+        return
+      end
       @tools[tool.name] = tool
     end
 

--- a/src/autobot/tools/sandbox_executor.cr
+++ b/src/autobot/tools/sandbox_executor.cr
@@ -15,11 +15,14 @@ module Autobot
       MAX_FILE_SIZE = 1_048_576
 
       getter? sandboxed : Bool = true
+      getter roots : Array(Path)
 
-      def initialize(@workspace : Path?, @sandboxed : Bool = true)
+      def initialize(@workspace : Path?, @sandboxed : Bool = true, @roots : Array(Path) = [] of Path)
       end
 
       def read_file(path : String) : ToolResult
+        outside_roots(path).try { |error| return error }
+
         if @sandboxed && (workspace = @workspace)
           read_file_via_sandbox_exec(path, workspace)
         else
@@ -32,6 +35,8 @@ module Autobot
       # Read a file and return base64-encoded contents.
       # Safe for binary files (images, GIFs, documents).
       def read_file_base64(path : String) : ToolResult
+        outside_roots(path).try { |error| return error }
+
         if @sandboxed && (workspace = @workspace)
           success, output = Sandbox.read_file_base64(path, workspace)
           success ? ToolResult.success(output) : ToolResult.error(output)
@@ -43,6 +48,8 @@ module Autobot
       end
 
       def write_file(path : String, content : String) : ToolResult
+        outside_roots(path).try { |error| return error }
+
         if @sandboxed && (workspace = @workspace)
           write_file_via_sandbox_exec(path, content, workspace)
         else
@@ -53,6 +60,8 @@ module Autobot
       end
 
       def list_dir(path : String) : ToolResult
+        outside_roots(path).try { |error| return error }
+
         if @sandboxed && (workspace = @workspace)
           list_dir_via_sandbox_exec(path, workspace)
         else
@@ -83,6 +92,17 @@ module Autobot
       end
 
       # Sandbox.exec-based execution
+      private def outside_roots(path : String) : ToolResult?
+        return nil if @roots.empty?
+
+        base = @workspace || Path[Dir.current]
+        resolved = Path[path].expand(base: base, home: true)
+        return nil if @roots.any? { |root| resolved == root || resolved.to_s.starts_with?("#{root}/") }
+
+        names = @roots.map(&.relative_to(base).to_s)
+        ToolResult.error("Path is outside the allowed directories (#{names.join(", ")}): #{path}")
+      end
+
       private def read_file_via_sandbox_exec(path : String, workspace : Path) : ToolResult
         success, output = Sandbox.read_file(path, workspace)
         success ? ToolResult.success(output) : ToolResult.error(output)

--- a/src/autobot/tools/tools.cr
+++ b/src/autobot/tools/tools.cr
@@ -30,8 +30,10 @@ module Autobot
       web_fetch_max_chars : Int32 = WebFetchTool::DEFAULT_MAX_CHARS,
       skills_dirs : Array(String) = [] of String,
       rate_limiter : RateLimiter? = nil,
+      enabled_tools : Array(String) = [] of String,
+      filesystem_roots : Array(String) = [] of String,
     ) : Registry
-      registry = Registry.new(rate_limiter: rate_limiter)
+      registry = Registry.new(rate_limiter: rate_limiter, allowlist: Allowlist.new(enabled_tools))
 
       # Determine sandbox configuration
       sandboxed = sandbox_config.downcase != "none"
@@ -45,7 +47,7 @@ module Autobot
       end
 
       # Create centralized sandbox executor
-      executor = SandboxExecutor.new(workspace, sandboxed)
+      executor = SandboxExecutor.new(workspace, sandboxed, resolve_roots(filesystem_roots, workspace))
 
       # Register tools
       register_filesystem_tools(registry, executor)
@@ -72,11 +74,13 @@ module Autobot
       sandbox_config : String = "auto",
       brave_api_key : String? = nil,
       rate_limiter : RateLimiter? = nil,
+      enabled_tools : Array(String) = [] of String,
+      filesystem_roots : Array(String) = [] of String,
     ) : Registry
-      registry = Registry.new(rate_limiter: rate_limiter)
+      registry = Registry.new(rate_limiter: rate_limiter, allowlist: Allowlist.new(enabled_tools))
 
       sandboxed = sandbox_config.downcase != "none"
-      executor = SandboxExecutor.new(workspace, sandboxed)
+      executor = SandboxExecutor.new(workspace, sandboxed, resolve_roots(filesystem_roots, workspace))
 
       register_filesystem_tools(registry, executor)
       register_exec_tool(registry, executor, exec_timeout, exec_deny_patterns,
@@ -90,6 +94,11 @@ module Autobot
       ::Log.for("Tools").info { "Registered #{registry.size} tools: #{registry.tool_names.join(", ")}" }
 
       registry
+    end
+
+    def self.resolve_roots(roots : Array(String), workspace : Path?) : Array(Path)
+      base = workspace || Path[Dir.current]
+      roots.map { |root| Path[root].expand(base: base, home: true) }
     end
 
     private def self.log_sandbox_configuration(sandbox_type : Sandbox::Type) : Nil


### PR DESCRIPTION
## Overview

- [x] `tools.enabled` allowlist applied at registration, covering built-in tools, skill scripts, plugins and MCP servers alike; patterns ending in `*` match by prefix with the matcher MCP already used
- [x] `tools.filesystem.roots` limits `read_file`, `write_file`, `edit_file` and `list_dir` to workspace subdirectories, checked in the executor in every sandbox mode; `exec` is not narrowed
- [x] subagents inherit both settings
- [x] `autobot doctor` prints the effective tool list, hints when no allowlist is set, warns about roots outside the workspace, and warns about an allowlist entry that matches no built-in tool, plugin tool, skill script or listed MCP tool
- [x] the registry logs once, when the tool list is first built, any allowlist entry that never matched a tool
- [x] both settings are optional, so existing configs behave exactly as before
- [x] specs for the allowlist, the registry, the executor roots, the setup path, doctor and the schema; docs for configuration, security and sandboxing