### PR TITLE
feat(tools): confirmation gate for mutating tools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,9 @@ tools:
     - list_dir
     - message
     - "ha_*"     # patterns ending in * match by prefix (skills, plugins, MCP tools)
+  confirm:       # Optional; these tools run only after the user types a code
+    - exec
+    - ha_call_service
   filesystem:
     roots: [notes, inbox]  # Optional; file tools may only touch these workspace subdirectories
   sandbox: auto  # auto | bubblewrap | docker | none (default: auto)
@@ -142,6 +145,10 @@ When sandboxed, all shell commands run inside the sandbox (bubblewrap or Docker)
 ### Tool Allowlist
 
 `tools.enabled` names the tools a bot may have. Anything not listed is never registered, whichever source it comes from: built-in tools, skill scripts, plugins and MCP servers all pass through the same check. A name ending in `*` matches by prefix, as in the MCP `tools:` list. Leave it out to keep today's behaviour of registering everything. `autobot doctor` prints the effective list and warns about an entry that matches no known tool, so a typo does not silently remove a tool; at startup the bot logs a warning for entries that matched nothing.
+
+### Confirmation Gate
+
+`tools.confirm` names tools that must not run on the model's say-so alone. When the model calls one, the call is held, the model is told to describe it and ask the user for a four-character code, and nothing runs. Typing that code in the chat within five minutes runs the held call and hands the result back to the model; anything else is treated as a normal message. The code has to be typed: a spoken message carries the transcription prefix and does not match, and text inside attachments never reaches the check. Background tasks such as subagents cannot confirm, so gated tools are refused there. Names use the same `name` or `prefix*` syntax as `tools.enabled`, and MCP tools can be gated by name.
 
 ### Filesystem Roots
 
@@ -307,6 +314,7 @@ tools:
     # model: gpt-image-1     # optional, auto-detected from provider
     # size: 1024x1024
   enabled: [read_file, write_file, edit_file, list_dir, message]  # optional allowlist
+  confirm: [exec, ha_call_service]  # optional, held until the user types a code
   filesystem:
     roots: [notes, inbox]      # optional, workspace subdirectories the file tools may touch
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -153,7 +153,7 @@ autobot doctor --strict # Fail on any warning (CI/CD)
 **⚠️ Warnings (review recommended):**
 
 - Filesystem root configured outside the workspace
-- `tools.enabled` entry that matches no known tool
+- `tools.enabled` or `tools.confirm` entry that matches no known tool
 - Gateway bound to 0.0.0.0 (network exposure)
 - Channel authorization not configured (empty `allow_from`)
 - Missing `.env` file
@@ -284,6 +284,15 @@ tools:
 ```
 
 `tools.enabled` is an allowlist applied at registration, so a tool that is not listed does not exist for the model, whether it is built in, a skill script, a plugin or an MCP tool. `tools.filesystem.roots` keeps the file tools inside the listed workspace subdirectories. With both in place, the worst a planted instruction inside an attachment can do is write a bad note. `autobot doctor` prints the effective tool list and reminds you to set the allowlist when it is missing.
+
+Some bots need a tool that changes the world, such as a Home Assistant service call. Put it in `tools.confirm`:
+
+```yaml
+tools:
+  confirm: [ha_call_service, ha_config_set_automation]
+```
+
+A gated call is held until the user types a four-character code in the chat, valid for five minutes. The code must be typed: spoken messages and attachment content never match it, and background tasks cannot confirm at all. This turns "the model decided to flip a switch" into "you decided", whatever the model was reading when it decided.
 
 ---
 

--- a/spec/autobot/agent/loop_spec.cr
+++ b/spec/autobot/agent/loop_spec.cr
@@ -11,6 +11,27 @@ class MockProvider < Autobot::Providers::HttpProvider
   end
 end
 
+class GatedTool < Autobot::Tools::Tool
+  def name : String
+    "gated"
+  end
+
+  def description : String
+    "A tool that needs confirmation"
+  end
+
+  def parameters : Autobot::Tools::ToolSchema
+    Autobot::Tools::ToolSchema.new(
+      properties: {"input" => Autobot::Tools::PropertySchema.new(type: "string", description: "Input")},
+      required: ["input"]
+    )
+  end
+
+  def execute(params : Hash(String, JSON::Any)) : Autobot::Tools::ToolResult
+    Autobot::Tools::ToolResult.success("ran #{params["input"].as_s}")
+  end
+end
+
 # Testable subclass exposing private methods for unit testing.
 class TestableLoop < Autobot::Agent::Loop
   def test_build_cron_prompt(msg : Autobot::Bus::InboundMessage) : String
@@ -251,6 +272,38 @@ describe Autobot::Agent::Loop do
       user_turn = sessions.get_or_create("telegram:user1").get_history.first["content"]
       user_turn.should start_with("Add to notes\n\n<attachment type=\"audio\"")
       user_turn.should contain("the dealer offered a discount")
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
+    it "runs a gated tool only when the user types its code" do
+      tmp = TestHelper.tmp_dir
+      sessions = Autobot::Session::Manager.new(tmp)
+      tools = Autobot::Tools::Registry.new(
+        confirm: Autobot::Tools::Allowlist.new(["gated"]),
+        confirmations: Autobot::Tools::ConfirmationStore.new
+      )
+      tools.register(Autobot::Tools::MessageTool.new)
+      tools.register(GatedTool.new)
+      loop_inst = TestableLoop.new(
+        bus: Autobot::Bus::MessageBus.new(capacity: 10),
+        provider: MockProvider.new,
+        workspace: tmp,
+        tools: tools,
+        sessions: sessions,
+        memory_window: 0,
+        sandbox_config: "none"
+      )
+      reply = tools.execute("gated", {"input" => JSON::Any.new("x")}, "telegram:user1")
+      code = reply.match(/code ([A-Z2-9]{4})/).try(&.[1]).to_s
+
+      spoken = Autobot::Bus::InboundMessage.new(channel: "telegram", sender_id: "user1", chat_id: "user1", content: "[voice transcription]: #{code}")
+      loop_inst.test_process_message(spoken)
+      sessions.get_or_create("telegram:user1").get_history.first["content"].should eq("[voice transcription]: #{code}")
+
+      typed = Autobot::Bus::InboundMessage.new(channel: "telegram", sender_id: "user1", chat_id: "user1", content: code)
+      loop_inst.test_process_message(typed)
+      sessions.get_or_create("telegram:user1").get_history.last(2).first["content"].should eq("Confirmed gated.\nResult:\nran x")
     ensure
       FileUtils.rm_rf(tmp) if tmp
     end

--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -615,6 +615,27 @@ describe Autobot::CLI::Doctor do
       end
     end
 
+    it "reports gated tools and warns about an unknown one" do
+      config = make_config(<<-YAML
+      tools:
+        confirm: [exec, ha_cal_service]
+      mcp:
+        servers:
+          homeassistant:
+            command: uvx
+            tools: [ha_call_service]
+      YAML
+      )
+
+      with_doctor_io do |io|
+        warnings = Autobot::CLI::Doctor.check_tools(config, 0)
+
+        warnings.should eq(1)
+        io.to_s.should contain("✓ Confirmation required before: exec, ha_cal_service")
+        io.to_s.should contain("match no known tool: ha_cal_service")
+      end
+    end
+
     it "passes roots inside the workspace and warns about roots outside it" do
       config = make_config(<<-YAML
       agents:

--- a/spec/autobot/config/schema_spec.cr
+++ b/spec/autobot/config/schema_spec.cr
@@ -182,6 +182,12 @@ describe Autobot::Config::Config do
       config.tools.try(&.filesystem.try(&.roots)).should eq(["notes", "inbox"])
     end
 
+    it "parses the confirmation list" do
+      config = Autobot::Config::Config.from_yaml("tools:\n  confirm: [ha_call_service, exec]\n")
+      config.tools.try(&.confirm).should eq(["ha_call_service", "exec"])
+      Autobot::Config::Config.from_yaml("{}").tools.try(&.confirm).should be_nil
+    end
+
     it "defaults to all tools and the whole workspace" do
       config = Autobot::Config::Config.from_yaml("tools:\n  sandbox: none\n")
       config.tools.try(&.enabled).should eq([] of String)

--- a/spec/autobot/tools/confirmation_spec.cr
+++ b/spec/autobot/tools/confirmation_spec.cr
@@ -1,0 +1,47 @@
+require "../../spec_helper"
+
+private def params(value : String) : Hash(String, JSON::Any)
+  {"input" => JSON::Any.new(value)}
+end
+
+describe Autobot::Tools::ConfirmationStore do
+  it "issues a short unambiguous code and redeems it once" do
+    store = Autobot::Tools::ConfirmationStore.new
+    pending = store.request("telegram:1", "exec", params("rm x"))
+
+    pending.code.size.should eq(4)
+    pending.code.each_char { |char| Autobot::Tools::ConfirmationStore::CODE_ALPHABET.includes?(char).should be_true }
+    store.pending?("telegram:1").should be_true
+
+    taken = store.take("telegram:1", " #{pending.code.downcase} ")
+    taken.try(&.name).should eq("exec")
+    taken.try(&.params).should eq(params("rm x"))
+    store.take("telegram:1", pending.code).should be_nil
+  end
+
+  it "ignores wrong codes and other sessions" do
+    store = Autobot::Tools::ConfirmationStore.new
+    pending = store.request("telegram:1", "exec", params("x"))
+
+    store.take("telegram:1", "NOPE").should be_nil
+    store.take("telegram:2", pending.code).should be_nil
+    store.pending?("telegram:1").should be_true
+  end
+
+  it "drops an expired code" do
+    store = Autobot::Tools::ConfirmationStore.new
+    pending = store.request("telegram:1", "exec", params("x"), ttl: -1.second)
+
+    store.take("telegram:1", pending.code).should be_nil
+    store.pending?("telegram:1").should be_false
+  end
+
+  it "keeps only the latest request per session" do
+    store = Autobot::Tools::ConfirmationStore.new
+    first = store.request("telegram:1", "exec", params("a"))
+    second = store.request("telegram:1", "exec", params("b"))
+
+    store.take("telegram:1", first.code).should be_nil
+    store.take("telegram:1", second.code).try(&.params).should eq(params("b"))
+  end
+end

--- a/spec/autobot/tools/registry_spec.cr
+++ b/spec/autobot/tools/registry_spec.cr
@@ -86,6 +86,44 @@ describe Autobot::Tools::Registry do
     Autobot::Tools::Registry.new.unmatched_patterns.should be_empty
   end
 
+  describe "confirmation gate" do
+    it "withholds a gated tool until the typed code arrives" do
+      registry = Autobot::Tools::Registry.new(
+        confirm: Autobot::Tools::Allowlist.new(["dum*"]),
+        confirmations: Autobot::Tools::ConfirmationStore.new
+      )
+      registry.register(DummyTool.new)
+      params = {"input" => JSON::Any.new("hi")}
+
+      reply = registry.execute("dummy", params, "telegram:1")
+      reply.should start_with("Confirmation required: dummy")
+      reply.should_not contain("echo: hi")
+      code = reply.match(/code ([A-Z2-9]{4})/).try(&.[1]).to_s
+
+      registry.confirm("telegram:1", "wrong").should be_nil
+      registry.confirm("telegram:1", code).should eq("Confirmed dummy.\nResult:\necho: hi")
+      registry.confirm("telegram:1", code).should be_nil
+    end
+
+    it "runs ungated tools directly" do
+      registry = Autobot::Tools::Registry.new(
+        confirm: Autobot::Tools::Allowlist.new(["exec"]),
+        confirmations: Autobot::Tools::ConfirmationStore.new
+      )
+      registry.register(DummyTool.new)
+
+      registry.execute("dummy", {"input" => JSON::Any.new("hi")}, "telegram:1").should eq("echo: hi")
+    end
+
+    it "refuses gated tools when nobody can confirm" do
+      registry = Autobot::Tools::Registry.new(confirm: Autobot::Tools::Allowlist.new(["dummy"]))
+      registry.register(DummyTool.new)
+
+      registry.execute("dummy", {"input" => JSON::Any.new("hi")}, "sub").should contain("cannot run in a background task")
+      registry.confirm("sub", "ABCD").should be_nil
+    end
+  end
+
   it "unregisters a tool" do
     registry = Autobot::Tools::Registry.new
     registry.register(DummyTool.new)

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -68,6 +68,7 @@ module Autobot::Agent
       rate_limiter : Tools::RateLimiter? = nil,
       enabled_tools : Array(String) = [] of String,
       filesystem_roots : Array(String) = [] of String,
+      confirm_tools : Array(String) = [] of String,
     )
       @model = model || @provider.default_model
       sandboxed = sandbox_config.downcase != "none"
@@ -88,7 +89,7 @@ module Autobot::Agent
         sessions: @sessions
       )
 
-      register_optional_tools(brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns, sandbox_config, rate_limiter, enabled_tools, filesystem_roots)
+      register_optional_tools(brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns, sandbox_config, rate_limiter, enabled_tools, filesystem_roots, confirm_tools)
       cache_tool_references
     end
 
@@ -161,9 +162,10 @@ module Autobot::Agent
       end
 
       update_tool_contexts(msg.channel, msg.chat_id)
+      content = @tools.confirm(session.key, msg.content) || msg.content
       messages = @context.build_messages(
         history: session.get_history,
-        current_message: msg.content,
+        current_message: content,
         media: msg.media?,
         channel: msg.channel,
         chat_id: msg.chat_id,
@@ -174,7 +176,7 @@ module Autobot::Agent
       result = @executor.execute(messages, @tools, session_key: session.key)
       final_content = result.content || FALLBACK_RESPONSE
 
-      save_to_session(session, @context.render_user_text(msg.content, msg.media?), final_content, result.tools_used)
+      save_to_session(session, @context.render_user_text(content, msg.media?), final_content, result.tools_used)
 
       # Skip automatic text response if the message tool already sent during this turn
       return nil if @message_tool.try(&.last_sent_content)
@@ -297,6 +299,7 @@ module Autobot::Agent
       rate_limiter : Tools::RateLimiter?,
       enabled_tools : Array(String),
       filesystem_roots : Array(String),
+      confirm_tools : Array(String),
     ) : Nil
       subagents = SubagentManager.new(
         provider: @provider,
@@ -311,6 +314,7 @@ module Autobot::Agent
         rate_limiter: rate_limiter,
         enabled_tools: enabled_tools,
         filesystem_roots: filesystem_roots,
+        confirm_tools: confirm_tools,
       )
       @tools.register(Tools::SpawnTool.new(subagents))
 

--- a/src/autobot/agent/subagent.cr
+++ b/src/autobot/agent/subagent.cr
@@ -57,6 +57,7 @@ module Autobot
         @rate_limiter : Tools::RateLimiter? = nil,
         @enabled_tools : Array(String) = [] of String,
         @filesystem_roots : Array(String) = [] of String,
+        @confirm_tools : Array(String) = [] of String,
       )
         @context = Context::Builder.new(@workspace)
       end
@@ -124,6 +125,7 @@ module Autobot
             rate_limiter: @rate_limiter,
             enabled_tools: @enabled_tools,
             filesystem_roots: @filesystem_roots,
+            confirm_tools: @confirm_tools,
           )
 
           executor = ToolExecutor.new(

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -179,13 +179,23 @@ module Autobot
         unless allowlist.restricted?
           report(Status::Pass, "Tools: all built-in tools, plus skills, plugins and MCP servers")
           hint("Set tools.enabled to limit this bot to the tools it needs")
+          warnings = check_confirm_tools(config, warnings)
           return check_filesystem_roots(config, warnings)
         end
 
         builtin = BUILTIN_TOOLS.select { |name| allowlist.allows?(name) }
         report(Status::Pass, "Tools limited to: #{builtin.empty? ? "none of the built-in tools" : builtin.join(", ")}")
         warnings = check_unknown_tools(config, allowlist, warnings)
+        warnings = check_confirm_tools(config, warnings)
         check_filesystem_roots(config, warnings)
+      end
+
+      def self.check_confirm_tools(config : Config::Config, warnings : Int32) : Int32
+        confirm = Tools::Allowlist.new(config.tools.try(&.confirm) || [] of String)
+        return warnings unless confirm.restricted?
+
+        report(Status::Pass, "Confirmation required before: #{confirm.patterns.join(", ")}")
+        check_unknown_tools(config, confirm, warnings)
       end
 
       def self.check_unknown_tools(config : Config::Config, allowlist : Tools::Allowlist, warnings : Int32) : Int32

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -162,6 +162,7 @@ module Autobot
           rate_limiter: rate_limiter,
           enabled_tools: config.tools.try(&.enabled) || [] of String,
           filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
+          confirm_tools: config.tools.try(&.confirm) || [] of String,
         )
       end
 

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -117,6 +117,7 @@ module Autobot
           rate_limiter: rate_limiter,
           enabled_tools: config.tools.try(&.enabled) || [] of String,
           filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
+          confirm_tools: config.tools.try(&.confirm) || [] of String,
         )
 
         register_image_tool(config, tool_registry)

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -292,6 +292,7 @@ module Autobot::Config
   class ToolsConfig
     include YAML::Serializable
     property enabled : Array(String) = [] of String
+    property confirm : Array(String) = [] of String
     property filesystem : FilesystemToolsConfig?
     property web : WebToolsConfig?
     property exec : ExecToolConfig?

--- a/src/autobot/tools/confirmation.cr
+++ b/src/autobot/tools/confirmation.cr
@@ -1,0 +1,59 @@
+require "json"
+require "random/secure"
+
+module Autobot::Tools
+  struct PendingConfirmation
+    getter code : String
+    getter name : String
+    getter params : Hash(String, JSON::Any)
+    getter expires_at : Time
+
+    def initialize(@code : String, @name : String, @params : Hash(String, JSON::Any), @expires_at : Time)
+    end
+
+    def expired?(now : Time = Time.utc) : Bool
+      now > @expires_at
+    end
+  end
+
+  # One pending gated tool call per session, redeemed by typing its code.
+  class ConfirmationStore
+    TTL           = 5.minutes
+    CODE_LENGTH   = 4
+    CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+    @pending = {} of String => PendingConfirmation
+    @mutex = Mutex.new
+
+    def request(session_key : String, name : String, params : Hash(String, JSON::Any), ttl : Time::Span = TTL) : PendingConfirmation
+      pending = PendingConfirmation.new(generate_code, name, params, Time.utc + ttl)
+      @mutex.synchronize { @pending[session_key] = pending }
+      pending
+    end
+
+    def take(session_key : String, text : String) : PendingConfirmation?
+      @mutex.synchronize do
+        pending = @pending[session_key]?
+        return nil unless pending
+
+        if pending.expired?
+          @pending.delete(session_key)
+          return nil
+        end
+        return nil unless text.strip.upcase == pending.code
+
+        @pending.delete(session_key)
+      end
+    end
+
+    def pending?(session_key : String) : Bool
+      @mutex.synchronize { @pending.has_key?(session_key) }
+    end
+
+    private def generate_code : String
+      String.build(CODE_LENGTH) do |io|
+        CODE_LENGTH.times { io << CODE_ALPHABET[Random::Secure.rand(CODE_ALPHABET.size)] }
+      end
+    end
+  end
+end

--- a/src/autobot/tools/registry.cr
+++ b/src/autobot/tools/registry.cr
@@ -1,5 +1,6 @@
 require "./allowlist"
 require "./base"
+require "./confirmation"
 require "./rate_limiter"
 require "./sandbox_executor"
 
@@ -14,13 +15,33 @@ module Autobot::Tools
     @sandbox_executor : SandboxExecutor?
 
     getter allowlist : Allowlist
+    getter confirm : Allowlist
     @matched_patterns = Set(String).new
     @warned_unmatched = false
 
-    def initialize(@session_key : String = "default", rate_limiter : RateLimiter? = nil, @allowlist : Allowlist = Allowlist.all)
+    def initialize(
+      @session_key : String = "default",
+      rate_limiter : RateLimiter? = nil,
+      @allowlist : Allowlist = Allowlist.all,
+      @confirm : Allowlist = Allowlist.all,
+      @confirmations : ConfirmationStore? = nil,
+    )
       @tools = {} of String => Tool
       @rate_limiter = rate_limiter || RateLimiter.new
       @sandbox_executor = nil
+    end
+
+    def gated?(name : String) : Bool
+      @confirm.restricted? && @confirm.allows?(name)
+    end
+
+    # Redeems a typed confirmation code; returns the tool outcome or nil when nothing matched.
+    def confirm(session_key : String, text : String) : String?
+      pending = @confirmations.try(&.take(session_key, text))
+      return nil unless pending
+
+      Log.info { "Confirmed tool #{pending.name} for #{session_key}" }
+      "Confirmed #{pending.name}.\nResult:\n#{execute(pending.name, pending.params, session_key, confirmed: true)}"
     end
 
     def register(tool : Tool) : Nil
@@ -78,6 +99,16 @@ module Autobot::Tools
       end
     end
 
+    private def request_confirmation(name : String, params : Hash(String, JSON::Any), session_key : String) : String
+      store = @confirmations
+      return "Error: #{name} requires the user's confirmation and cannot run in a background task" unless store
+
+      pending = store.request(session_key, name, params)
+      Log.info { "Confirmation requested for tool #{name} (#{session_key})" }
+      "Confirmation required: #{name} with #{params.to_json} will run only after the user types the code #{pending.code} " \
+      "(valid for 5 minutes, replaces any earlier pending code). Tell the user what will happen and ask them to type the code."
+    end
+
     private def warn_unmatched_once : Nil
       return if @warned_unmatched
       @warned_unmatched = true
@@ -87,7 +118,7 @@ module Autobot::Tools
       Log.warn { "tools.enabled entries matched no tool: #{unmatched.join(", ")}" }
     end
 
-    def execute(name : String, params : Hash(String, JSON::Any), session_key : String? = nil) : String
+    def execute(name : String, params : Hash(String, JSON::Any), session_key : String? = nil, confirmed : Bool = false) : String
       tool = @tools[name]?
 
       unless tool
@@ -96,6 +127,10 @@ module Autobot::Tools
 
       # Use provided session key or fall back to instance default
       effective_session_key = session_key || @session_key
+
+      if gated?(name) && !confirmed
+        return request_confirmation(name, params, effective_session_key)
+      end
 
       if error = @rate_limiter.check_limit(name, effective_session_key)
         Log.warn { "Rate limit exceeded for tool #{name}: #{error}" }

--- a/src/autobot/tools/tools.cr
+++ b/src/autobot/tools/tools.cr
@@ -32,8 +32,14 @@ module Autobot
       rate_limiter : RateLimiter? = nil,
       enabled_tools : Array(String) = [] of String,
       filesystem_roots : Array(String) = [] of String,
+      confirm_tools : Array(String) = [] of String,
     ) : Registry
-      registry = Registry.new(rate_limiter: rate_limiter, allowlist: Allowlist.new(enabled_tools))
+      registry = Registry.new(
+        rate_limiter: rate_limiter,
+        allowlist: Allowlist.new(enabled_tools),
+        confirm: Allowlist.new(confirm_tools),
+        confirmations: ConfirmationStore.new,
+      )
 
       # Determine sandbox configuration
       sandboxed = sandbox_config.downcase != "none"
@@ -76,8 +82,9 @@ module Autobot
       rate_limiter : RateLimiter? = nil,
       enabled_tools : Array(String) = [] of String,
       filesystem_roots : Array(String) = [] of String,
+      confirm_tools : Array(String) = [] of String,
     ) : Registry
-      registry = Registry.new(rate_limiter: rate_limiter, allowlist: Allowlist.new(enabled_tools))
+      registry = Registry.new(rate_limiter: rate_limiter, allowlist: Allowlist.new(enabled_tools), confirm: Allowlist.new(confirm_tools))
 
       sandboxed = sandbox_config.downcase != "none"
       executor = SandboxExecutor.new(workspace, sandboxed, resolve_roots(filesystem_roots, workspace))


### PR DESCRIPTION
## Overview

- [x] `tools.confirm` names tools that are held until the user types a four-character code in the chat, valid for five minutes, one pending call per session
- [x] the model receives the request as the tool result and is told to describe the call and ask for the code; typing it runs the held call and hands the outcome back to the model as the next turn
- [x] the code must be typed: a spoken message carries the transcription prefix and does not match, and attachment content never reaches the check
- [x] subagents cannot confirm, so gated tools are refused in background registries
- [x] MCP tools can be gated by name with the same `name` or `prefix*` syntax as `tools.enabled`
- [x] `autobot doctor` reports the gated tools and warns about an entry that matches no known tool
- [x] specs for the store, the registry gate, the loop round-trip, doctor and the schema; docs for configuration and security