### PR TITLE
feat(tools): redact credentials from tool results

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -199,7 +199,7 @@ All filesystem and exec operations go through `SandboxExecutor`, which routes th
 ### What Sandboxing Does NOT Prevent
 
 - Network attacks (agent has network access)
-- API key theft (main process has keys)
+- API key theft (main process has keys; tool results are redacted before they reach the model, see [Security](security.md#secrets-in-tool-output))
 - DoS via API calls
 - Social engineering (user approves actions)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -119,9 +119,17 @@ ANTHROPIC_API_KEY=sk-ant-your-secret-key
 - ✅ `./.env` (outside workspace)
 - ❌ `./workspace/.env` (inside workspace - BLOCKED by validation)
 
+### Secrets in Tool Output
+
+Whatever a tool returns becomes part of the next prompt. The sandbox limits what a command can read, not what a tool returns: a script that fails with its request headers in the stack trace, or an MCP server that echoes its configuration in an error, would hand a token you passed in through `sandbox_env` to the model and, depending on the provider, to its training data.
+
+**Credential redaction** runs on every tool result before it reaches the model, whether the tool is built in, a skill script, a plugin or an MCP server. Provider keys, bearer tokens, `token=`, `password=`, `*_api_key=` and `*_secret=` assignments and authorization headers are replaced with `[REDACTED]`. Long identifiers such as commit hashes and base64 content are left alone.
+
+This is defense in depth. Keep secrets outside the workspace and reference them from `config.yml` with `${VAR}` so there is nothing to leak in the first place.
+
 ### Log Sanitization
 
-**Automatic log sanitization** redacts:
+**Automatic log sanitization** redacts everything credential redaction does, plus any long alphanumeric token that looks like a key:
 
 - API keys (sk-ant-, sk-, AKIA, etc.)
 - Bearer tokens

--- a/spec/autobot/tools/registry_spec.cr
+++ b/spec/autobot/tools/registry_spec.cr
@@ -24,6 +24,29 @@ class DummyTool < Autobot::Tools::Tool
   end
 end
 
+class LeakyTool < Autobot::Tools::Tool
+  def name : String
+    "leaky"
+  end
+
+  def description : String
+    "Returns whatever it is given"
+  end
+
+  def parameters : Autobot::Tools::ToolSchema
+    Autobot::Tools::ToolSchema.new(
+      properties: {
+        "text" => Autobot::Tools::PropertySchema.new(type: "string", description: "Text to return"),
+      },
+      required: ["text"]
+    )
+  end
+
+  def execute(params : Hash(String, JSON::Any)) : Autobot::Tools::ToolResult
+    Autobot::Tools::ToolResult.success(params["text"].as_s)
+  end
+end
+
 class FailingTool < Autobot::Tools::Tool
   def name : String
     "failing"
@@ -188,5 +211,25 @@ describe Autobot::Tools::Registry do
 
     defs = registry.definitions(compact: nil)
     defs[0]["function"]["description"].as_s.should eq("A dummy tool for testing")
+  end
+
+  describe "credential redaction" do
+    it "redacts keys and tokens from every tool result" do
+      registry = Autobot::Tools::Registry.new
+      registry.register(LeakyTool.new)
+      leaked = "OPENAI_API_KEY=sk-abcdefghijklmnop123456\nTELEGRAM_BOT_TOKEN=123456:AbC-dEf\nBRAVE_API_KEY=BSAxyz"
+
+      output = registry.execute("leaky", {"text" => JSON::Any.new(leaked)})
+
+      output.should eq("OPENAI_API_KEY=[REDACTED]\nTELEGRAM_BOT_token=[REDACTED]\nBRAVE_API_KEY=[REDACTED]")
+    end
+
+    it "leaves hashes and encoded content alone" do
+      registry = Autobot::Tools::Registry.new
+      registry.register(LeakyTool.new)
+      content = "commit 3f2a9c1d8e7b6a5f4c3d2e1f0a9b8c7d6e5f4a3b\naW1hZ2VieXRlc2FyZWxvbmdlcnRoYW50d2VudHk="
+
+      registry.execute("leaky", {"text" => JSON::Any.new(content)}).should eq(content)
+    end
   end
 end

--- a/spec/security_spec.cr
+++ b/spec/security_spec.cr
@@ -242,6 +242,15 @@ describe "Security Tests" do
       sanitized.should contain("user=john") # Non-sensitive params should remain
     end
 
+    it "redacts credentials without touching long identifiers" do
+      text = "api_key: BSAxyz123 sha 3f2a9c1d8e7b6a5f4c3d2e1f0a9b8c7d6e5f4a3b"
+
+      redacted = Autobot::LogSanitizer.redact_credentials(text)
+
+      redacted.should eq("api_key=[REDACTED] sha 3f2a9c1d8e7b6a5f4c3d2e1f0a9b8c7d6e5f4a3b")
+      Autobot::LogSanitizer.sanitize(text).should contain("[REDACTED_KEY]")
+    end
+
     it "detects sensitive data in text" do
       Autobot::LogSanitizer.contains_sensitive_data?("sk-ant-123456").should be_true
       Autobot::LogSanitizer.contains_sensitive_data?("Hello world").should be_false

--- a/src/autobot/log_sanitizer.cr
+++ b/src/autobot/log_sanitizer.cr
@@ -1,19 +1,20 @@
 module Autobot
   module LogSanitizer
-    URL_KEY_PARAMS = /([?&])(api_key|apikey|key|token)=([^&\s]+)/i
-    BEARER_TOKEN   = /Bearer\s+[A-Za-z0-9_\-\.]+/i
-    ANTHROPIC_KEY  = /sk-ant-[A-Za-z0-9_-]+/
-    OPENAI_KEY     = /sk-[A-Za-z0-9]{16,}/
-    AWS_KEY        = /AKIA[A-Z0-9]{16}/
-    TOKEN_VALUE    = /token[=:]\s*['"]*([A-Za-z0-9_\-\.]+)['"]*\b/i
-    PASSWORD_VALUE = /password[=:]\s*['"]*([^&\s'"]+)['"]*\b/i
-    AUTH_HEADER    = /Authorization:\s*([^\s]+)/i
-    API_KEY_HEADER = /x-api-key:\s*([^\s]+)/i
-    GENERIC_KEY    = /\b[A-Za-z0-9]+[-_]?[A-Za-z0-9]{20,}\b/
+    URL_KEY_PARAMS    = /([?&])(api_key|apikey|key|token)=([^&\s]+)/i
+    BEARER_TOKEN      = /Bearer\s+[A-Za-z0-9_\-\.]+/i
+    ANTHROPIC_KEY     = /sk-ant-[A-Za-z0-9_-]+/
+    OPENAI_KEY        = /sk-[A-Za-z0-9]{16,}/
+    AWS_KEY           = /AKIA[A-Z0-9]{16}/
+    TOKEN_VALUE       = /token[=:]\s*['"]*([^&\s'"]+)['"]*/i
+    PASSWORD_VALUE    = /password[=:]\s*['"]*([^&\s'"]+)['"]*\b/i
+    SECRET_ASSIGNMENT = /\b(\w*(?:api[_-]?key|secret|passwd))\s*[=:]\s*['"]*([^&\s'"]+)['"]*/i
+    AUTH_HEADER       = /Authorization:\s*([^\s]+)/i
+    API_KEY_HEADER    = /x-api-key:\s*([^\s]+)/i
+    GENERIC_KEY       = /\b[A-Za-z0-9]+[-_]?[A-Za-z0-9]{20,}\b/
 
     SENSITIVE_URL_PARAMS = {"api_key", "apikey", "key", "token", "secret", "password"}
 
-    PATTERNS = [
+    CREDENTIAL_PATTERNS = [
       {pattern: URL_KEY_PARAMS, replacement: "\\1\\2=[REDACTED]"},
       {pattern: BEARER_TOKEN, replacement: "Bearer [REDACTED]"},
       {pattern: ANTHROPIC_KEY, replacement: "sk-ant-[REDACTED]"},
@@ -21,19 +22,19 @@ module Autobot
       {pattern: AWS_KEY, replacement: "AKIA[REDACTED]"},
       {pattern: TOKEN_VALUE, replacement: "token=[REDACTED]"},
       {pattern: PASSWORD_VALUE, replacement: "password=[REDACTED]"},
+      {pattern: SECRET_ASSIGNMENT, replacement: "\\1=[REDACTED]"},
       {pattern: AUTH_HEADER, replacement: "Authorization: [REDACTED]"},
       {pattern: API_KEY_HEADER, replacement: "x-api-key: [REDACTED]"},
-      {pattern: GENERIC_KEY, replacement: "[REDACTED_KEY]"},
     ]
 
+    PATTERNS = CREDENTIAL_PATTERNS + [{pattern: GENERIC_KEY, replacement: "[REDACTED_KEY]"}]
+
     def self.sanitize(message : String) : String
-      result = message
+      apply(PATTERNS, message)
+    end
 
-      PATTERNS.each do |pattern_info|
-        result = result.gsub(pattern_info[:pattern], pattern_info[:replacement])
-      end
-
-      result
+    def self.redact_credentials(text : String) : String
+      apply(CREDENTIAL_PATTERNS, text)
     end
 
     def self.sanitize_url(url : String) : String
@@ -58,6 +59,10 @@ module Autobot
 
     def self.contains_sensitive_data?(text : String) : Bool
       PATTERNS.any?(&.[:pattern].matches?(text))
+    end
+
+    private def self.apply(patterns, text : String) : String
+      patterns.reduce(text) { |result, entry| result.gsub(entry[:pattern], entry[:replacement]) }
     end
   end
 end

--- a/src/autobot/tools/registry.cr
+++ b/src/autobot/tools/registry.cr
@@ -127,7 +127,7 @@ module Autobot::Tools
 
         @rate_limiter.record_call(name, effective_session_key)
 
-        result.to_s
+        LogSanitizer.redact_credentials(result.to_s)
       rescue ex : Exception
         error_msg = "Error executing #{name}"
         Log.error { error_msg }


### PR DESCRIPTION
## Overview

- [x] credential redaction applied to every tool result at the registry, covering built-in, skill, plugin and MCP tools
- [x] sanitizer split into credential patterns and the broader log set, so hashes and base64 in tool output stay intact
- [x] `*_api_key=` and `*_secret=` assignments redacted; `token=` values no longer leak past a colon
- [x] specs for the redacted registry output and the pattern split
- [x] security and sandboxing docs updated