### PR TITLE
feat(config): transcription settings per bot

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,12 +35,16 @@ Supported provider blocks — see the **[Providers overview](providers.md)** for
 
 ## Voice Transcription
 
-Voice messages are automatically transcribed using the Whisper API when a supported provider is configured. No extra settings needed — the API key is reused from the provider config.
+Voice notes are transcribed with the Whisper API. By default the key is reused from the chat provider config, Groq first (`whisper-large-v3-turbo`), then OpenAI (`whisper-1`). The `transcription` section changes that per bot:
 
-- **Groq** (preferred — faster, free tier): uses `whisper-large-v3-turbo`
-- **OpenAI**: uses `whisper-1`
+```yaml
+transcription:
+  enabled: true              # false: voice notes are never transcribed
+  provider: groq             # openai or groq; default picks groq, then openai
+  api_key: "${WHISPER_KEY}"  # own key, separate from the chat provider
+```
 
-If neither Groq nor OpenAI is configured, voice messages fall back to `[voice message]` text.
+With `enabled: false`, or when no key is available, a voice note is saved to the inbox without a transcript and the bot replies that it could not hear it, without a model turn. `autobot doctor` prints the provider in use, whether it runs on its own key, and warns when a pinned provider has no key.
 
 ## Media
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -283,23 +283,26 @@ Audio file or forwarded note -> Download -> Transcriber -> transcript on the att
 
 ### Configuration
 
-No extra configuration needed. Voice transcription is auto-enabled when a Whisper-capable provider (Groq or OpenAI) is configured:
+Voice transcription is on by default and borrows the key of a Whisper-capable chat provider, Groq first, then OpenAI:
 
 ```yaml
 providers:
   groq:
-    api_key: "${GROQ_API_KEY}"  # Voice transcription auto-enabled via Groq Whisper
+    api_key: "${GROQ_API_KEY}"  # Voice transcription enabled via Groq Whisper
 ```
 
-Or:
+The `transcription` section overrides that per bot:
 
 ```yaml
-providers:
-  openai:
-    api_key: "${OPENAI_API_KEY}"  # Voice transcription auto-enabled via OpenAI Whisper
+transcription:
+  enabled: true                   # false turns transcription off for this bot
+  provider: openai                # pin openai or groq instead of the groq-then-openai default
+  api_key: "${TRANSCRIPTION_KEY}" # a key of its own, so audio never touches the chat provider's account
 ```
 
-Groq is preferred when both are configured (faster, has free tier). If neither is configured, voice notes fall back to `[voice message]` text with no errors, and audio files arrive as attachments without a transcript.
+`api_key` without `provider` uses OpenAI. A pinned provider without any key leaves transcription unavailable, and `autobot doctor` says so.
+
+When transcription is off or unavailable, a voice note the sender recorded is still saved to the inbox as an attachment without a transcript, but it is not sent to the model: the bot answers with a fixed reply that it could not hear the note and asks for typed text. Audio files and forwarded voice notes arrive as attachments without a transcript and the model is told so.
 
 ### Supported providers
 
@@ -314,10 +317,13 @@ Run `autobot doctor` to check voice transcription status:
 
 ```
 ✓ Voice transcription available (groq)
+✓ Voice transcription available (openai, own key)
 ```
 
-Or if no provider is configured:
+Or when it is off, or no provider is configured:
 
 ```
+— Voice transcription disabled
 — Voice transcription (no openai/groq provider)
+! Voice transcription enabled but no api key for openai
 ```

--- a/docs/media.md
+++ b/docs/media.md
@@ -47,6 +47,7 @@ Transcripts of content attachments are written next to the media file as
 | `origin` | `sender` or `forwarded` |
 | `file_path` | Where the file was saved in the inbox |
 | `transcript`, `transcript_path` | Transcript of a content attachment |
+| `transcribed` | Whether a transcript was produced; false for a voice note nobody could hear |
 | `duration_seconds`, `name`, `mime_type`, `size_bytes` | Metadata from the platform |
 
 `sender_voice_note?` is true only for a voice note with origin `sender`; the channel treats such a note as spoken words unless typed text came with it.

--- a/docs/security.md
+++ b/docs/security.md
@@ -295,7 +295,20 @@ tools:
 
 ---
 
-## 13. Known Limitations
+## 13. Transcription Per Bot
+
+Speech is the one kind of content that becomes instruction: a voice note the sender records is transcribed into the message text. The `transcription` section decides, per bot, whether that happens and with whose key:
+
+```yaml
+transcription:
+  enabled: false
+```
+
+A bot with transcription off never hears a voice note. The note is saved to the inbox as an attachment without a transcript and the bot answers with a fixed reply, with no model turn. A bot that should hear voice notes but must not share audio with the chat provider's account gets `transcription.api_key` of its own. `autobot doctor` prints the setting.
+
+---
+
+## 14. Known Limitations
 
 **WhatsApp Bridge:** WebSocket connection has no authentication (ws://).
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -99,7 +99,7 @@ channels:
 
 - **Long polling** — no webhook or public IP needed
 - **Reply context** — when replying to a message, the original text is included as context so the bot understands what you're referring to
-- **Voice notes** — a note recorded in the chat is auto-transcribed via Whisper into the message text (requires Groq or OpenAI provider)
+- **Voice notes** — a note recorded in the chat is transcribed via Whisper into the message text (Groq or OpenAI key, or the bot's own `transcription.api_key`); with transcription off the bot replies that it could not hear the note
 - **Audio files and forwarded voice notes** — saved to the inbox as attachments; the transcript stays on the attachment, never in the message text
 - **Photos** — sent as image attachments to the LLM and saved to the inbox
 - **Documents** — saved to the inbox and attached to the message context

--- a/spec/autobot/agent/loop_spec.cr
+++ b/spec/autobot/agent/loop_spec.cr
@@ -299,7 +299,7 @@ describe Autobot::Agent::Loop do
         channel: "telegram",
         sender_id: "user1",
         chat_id: "chat1",
-        content: Autobot::Bus::InboundMessage::UNHEARD_VOICE_NOTE,
+        content: "Someone: [voice message]",
         media: [Autobot::Bus::MediaAttachment.new(type: "voice", file_path: "/inbox/note.ogg")],
         metadata: {"thread_ts" => "1"},
       )

--- a/spec/autobot/agent/loop_spec.cr
+++ b/spec/autobot/agent/loop_spec.cr
@@ -292,6 +292,26 @@ describe Autobot::Agent::Loop do
       FileUtils.rm_rf(tmp) if tmp
     end
 
+    it "answers an unheard voice note without a model turn" do
+      tmp = TestHelper.tmp_dir
+      loop_inst = create_test_loop(workspace: tmp)
+      msg = Autobot::Bus::InboundMessage.new(
+        channel: "telegram",
+        sender_id: "user1",
+        chat_id: "chat1",
+        content: Autobot::Bus::InboundMessage::UNHEARD_VOICE_NOTE,
+        media: [Autobot::Bus::MediaAttachment.new(type: "voice", file_path: "/inbox/note.ogg")],
+        metadata: {"thread_ts" => "1"},
+      )
+
+      response = loop_inst.test_process_message(msg)
+      response.try(&.content).should eq(Autobot::Agent::Loop::VOICE_NOTE_NOT_HEARD)
+      response.try(&.metadata["thread_ts"]).should eq("1")
+      Autobot::Session::Manager.new(tmp).get_or_create("telegram:chat1").get_history.should be_empty
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
     it "preserves inbound metadata in outbound response" do
       tmp = TestHelper.tmp_dir
       loop_inst = create_test_loop(workspace: tmp)

--- a/spec/autobot/bus/events_spec.cr
+++ b/spec/autobot/bus/events_spec.cr
@@ -5,6 +5,17 @@ private def inbound(content : String, media : Array(Autobot::Bus::MediaAttachmen
 end
 
 describe Autobot::Bus::InboundMessage do
+  it "knows a sender voice note nobody transcribed" do
+    unheard = Autobot::Bus::MediaAttachment.new(type: "voice")
+    heard = Autobot::Bus::MediaAttachment.new(type: "voice", transcribed: true)
+    forwarded = Autobot::Bus::MediaAttachment.new(type: "voice", origin: "forwarded")
+
+    inbound("[voice message]", [unheard]).unheard_voice_note?.should be_true
+    inbound("[voice transcription]: hi", [heard]).unheard_voice_note?.should be_false
+    inbound("[voice message]", [forwarded]).unheard_voice_note?.should be_false
+    inbound("hi", nil).unheard_voice_note?.should be_false
+  end
+
   it "creates an inbound message" do
     msg = Autobot::Bus::InboundMessage.new(
       channel: "telegram",
@@ -144,17 +155,6 @@ describe Autobot::Bus::MediaAttachment do
     Autobot::Bus::MediaAttachment.new(type: "document").sender_voice_note?.should be_false
   end
 
-  it "knows a sender voice note nobody transcribed" do
-    voice = Autobot::Bus::MediaAttachment.new(type: "voice")
-    forwarded = Autobot::Bus::MediaAttachment.new(type: "voice", origin: "forwarded")
-    unheard = Autobot::Bus::InboundMessage::UNHEARD_VOICE_NOTE
-
-    inbound(unheard, [voice]).unheard_voice_note?.should be_true
-    inbound(unheard, [forwarded]).unheard_voice_note?.should be_false
-    inbound("[voice transcription]: hi", [voice]).unheard_voice_note?.should be_false
-    inbound(unheard, nil).unheard_voice_note?.should be_false
-  end
-
   it "round-trips attachment details through JSON" do
     media = Autobot::Bus::MediaAttachment.new(
       type: "audio",
@@ -169,6 +169,7 @@ describe Autobot::Bus::MediaAttachment do
     parsed = Autobot::Bus::MediaAttachment.from_json(media.to_json)
     parsed.origin.should eq("forwarded")
     parsed.transcript.should eq("spoken words")
+    parsed.transcribed?.should be_true
     parsed.transcript_path.should eq("/inbox/memo.txt")
     parsed.duration_seconds.should eq(134)
     parsed.name.should eq("Car dealer")
@@ -177,5 +178,6 @@ describe Autobot::Bus::MediaAttachment do
   it "parses attachments written before origin existed" do
     parsed = Autobot::Bus::MediaAttachment.from_json(%({"type": "photo", "url": "f1"}))
     parsed.origin.should eq("sender")
+    parsed.transcribed?.should be_false
   end
 end

--- a/spec/autobot/bus/events_spec.cr
+++ b/spec/autobot/bus/events_spec.cr
@@ -1,5 +1,9 @@
 require "../../spec_helper"
 
+private def inbound(content : String, media : Array(Autobot::Bus::MediaAttachment)?) : Autobot::Bus::InboundMessage
+  Autobot::Bus::InboundMessage.new(channel: "telegram", sender_id: "u1", chat_id: "c1", content: content, media: media)
+end
+
 describe Autobot::Bus::InboundMessage do
   it "creates an inbound message" do
     msg = Autobot::Bus::InboundMessage.new(
@@ -138,6 +142,17 @@ describe Autobot::Bus::MediaAttachment do
     Autobot::Bus::MediaAttachment.new(type: "voice", origin: "forwarded").sender_voice_note?.should be_false
     Autobot::Bus::MediaAttachment.new(type: "audio").sender_voice_note?.should be_false
     Autobot::Bus::MediaAttachment.new(type: "document").sender_voice_note?.should be_false
+  end
+
+  it "knows a sender voice note nobody transcribed" do
+    voice = Autobot::Bus::MediaAttachment.new(type: "voice")
+    forwarded = Autobot::Bus::MediaAttachment.new(type: "voice", origin: "forwarded")
+    unheard = Autobot::Bus::InboundMessage::UNHEARD_VOICE_NOTE
+
+    inbound(unheard, [voice]).unheard_voice_note?.should be_true
+    inbound(unheard, [forwarded]).unheard_voice_note?.should be_false
+    inbound("[voice transcription]: hi", [voice]).unheard_voice_note?.should be_false
+    inbound(unheard, nil).unheard_voice_note?.should be_false
   end
 
   it "round-trips attachment details through JSON" do

--- a/spec/autobot/channels/telegram_media_spec.cr
+++ b/spec/autobot/channels/telegram_media_spec.cr
@@ -48,6 +48,7 @@ describe Autobot::Channels::TelegramMedia do
       attachment = attachments.first
       attachment.sender_voice_note?.should be_true
       attachment.transcript.should be_nil
+      attachment.transcribed?.should be_true
       attachment.duration_seconds.should eq(7)
       attachment.size_bytes.should eq(512)
       transcriber.calls.should eq(["audio.ogg"])
@@ -60,6 +61,7 @@ describe Autobot::Channels::TelegramMedia do
 
       parts.should eq(["[voice message]"])
       attachments.first.transcript.should be_nil
+      attachments.first.transcribed?.should be_false
     end
 
     it "is content when typed text accompanies it" do

--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -406,6 +406,56 @@ describe Autobot::CLI::Doctor do
       end
     end
 
+    it "skips when transcription is disabled" do
+      config = make_config(<<-YAML
+      transcription:
+        enabled: false
+      providers:
+        groq:
+          api_key: "gsk-test-key"
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_voice_transcription(config)
+
+        io.to_s.should contain("— Voice transcription disabled")
+      end
+    end
+
+    it "shows a dedicated key" do
+      config = make_config(<<-YAML
+      transcription:
+        provider: groq
+        api_key: "gsk-own-key"
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_voice_transcription(config)
+
+        io.to_s.should contain("✓ Voice transcription available (groq, own key)")
+      end
+    end
+
+    it "warns when the pinned provider has no key" do
+      config = make_config(<<-YAML
+      transcription:
+        provider: openai
+      providers:
+        groq:
+          api_key: "gsk-test-key"
+      YAML
+      )
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_voice_transcription(config)
+
+        io.to_s.should contain("! Voice transcription enabled but no api key for openai")
+        io.to_s.should contain("transcription.api_key or providers.openai.api_key")
+      end
+    end
+
     it "prefers groq over openai" do
       config = make_config(<<-YAML
       providers:

--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -438,6 +438,16 @@ describe Autobot::CLI::Doctor do
       end
     end
 
+    it "fails on an unknown provider" do
+      config = make_config("transcription:\n  provider: whisperx\n")
+
+      with_doctor_io do |io|
+        Autobot::CLI::Doctor.check_voice_transcription(config)
+
+        io.to_s.should contain("✗ Unknown transcription provider 'whisperx'")
+      end
+    end
+
     it "warns when the pinned provider has no key" do
       config = make_config(<<-YAML
       transcription:

--- a/spec/autobot/config/schema_spec.cr
+++ b/spec/autobot/config/schema_spec.cr
@@ -188,6 +188,21 @@ describe Autobot::Config::Config do
       Autobot::Config::Config.from_yaml("tools:\n  web:\n    search:\n      api_key: x\n").tools.try(&.web.try(&.allowed_domains)).should eq([] of String)
     end
 
+    it "defaults transcription to enabled with no provider or key" do
+      config = Autobot::Config::Config.from_yaml("{}")
+      config.transcription.enabled?.should be_true
+      config.transcription.provider.should be_nil
+      config.transcription.own_key.should be_nil
+    end
+
+    it "parses the transcription section" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  enabled: false\n  provider: groq\n  api_key: gsk\n")
+      config.transcription.enabled?.should be_false
+      config.transcription.provider.should eq("groq")
+      config.transcription.own_key.should eq("gsk")
+      Autobot::Config::Config.from_yaml("transcription:\n  api_key: \"\"\n").transcription.own_key.should be_nil
+    end
+
     it "defaults to all tools and the whole workspace" do
       config = Autobot::Config::Config.from_yaml("tools:\n  sandbox: none\n")
       config.tools.try(&.enabled).should eq([] of String)

--- a/spec/autobot/config/schema_spec.cr
+++ b/spec/autobot/config/schema_spec.cr
@@ -200,7 +200,13 @@ describe Autobot::Config::Config do
       config.transcription.enabled?.should be_false
       config.transcription.provider.should eq("groq")
       config.transcription.own_key.should eq("gsk")
+      config.transcription.provider_known?.should be_true
+    end
+
+    it "ignores an empty or unexpanded own key" do
       Autobot::Config::Config.from_yaml("transcription:\n  api_key: \"\"\n").transcription.own_key.should be_nil
+      Autobot::Config::Config.from_yaml("transcription:\n  api_key: \"${WHISPER_KEY}\"\n").transcription.own_key.should be_nil
+      Autobot::Config::Config.from_yaml("transcription:\n  provider: whisperx\n").transcription.provider_known?.should be_false
     end
 
     it "defaults to all tools and the whole workspace" do
@@ -216,6 +222,37 @@ describe Autobot::Config::Config do
       path = config.workspace_path
       path.to_s.should_not contain("~")
       path.to_s.should contain("autobot")
+    end
+  end
+
+  describe "#transcription_source" do
+    it "prefers groq over openai when both chat providers have keys" do
+      source = Autobot::Config::Config.from_yaml("providers:\n  groq:\n    api_key: gsk\n  openai:\n    api_key: sk\n").transcription_source
+      source.should eq(Autobot::Config::TranscriptionConfig::Source.new("groq", "gsk", own_key: false))
+    end
+
+    it "is nil when no chat provider can transcribe or the key is unexpanded" do
+      Autobot::Config::Config.from_yaml("providers:\n  anthropic:\n    api_key: ant\n").transcription_source.should be_nil
+      Autobot::Config::Config.from_yaml("providers:\n  groq:\n    api_key: \"${GROQ_API_KEY}\"\n").transcription_source.should be_nil
+      Autobot::Config::Config.from_yaml("{}").transcription_source.should be_nil
+    end
+
+    it "is nil when transcription is disabled" do
+      Autobot::Config::Config.from_yaml("transcription:\n  enabled: false\nproviders:\n  groq:\n    api_key: gsk\n").transcription_source.should be_nil
+    end
+
+    it "uses only the pinned provider's chat key" do
+      both = "providers:\n  groq:\n    api_key: gsk\n  openai:\n    api_key: sk\n"
+      source = Autobot::Config::Config.from_yaml("transcription:\n  provider: openai\n" + both).transcription_source
+      source.should eq(Autobot::Config::TranscriptionConfig::Source.new("openai", "sk", own_key: false))
+      Autobot::Config::Config.from_yaml("transcription:\n  provider: openai\nproviders:\n  groq:\n    api_key: gsk\n").transcription_source.should be_nil
+    end
+
+    it "uses its own key ahead of the chat providers, on openai unless pinned" do
+      source = Autobot::Config::Config.from_yaml("transcription:\n  api_key: own\nproviders:\n  groq:\n    api_key: gsk\n").transcription_source
+      source.should eq(Autobot::Config::TranscriptionConfig::Source.new("openai", "own", own_key: true))
+      pinned = Autobot::Config::Config.from_yaml("transcription:\n  provider: groq\n  api_key: own\n").transcription_source
+      pinned.should eq(Autobot::Config::TranscriptionConfig::Source.new("groq", "own", own_key: true))
     end
   end
 

--- a/spec/autobot/config/validator_spec.cr
+++ b/spec/autobot/config/validator_spec.cr
@@ -253,6 +253,23 @@ describe Autobot::Config::Validator do
 end
 
 describe Autobot::Config::ConfigValidator do
+  describe "transcription validation" do
+    it "rejects an unknown transcription provider" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: whisperx\n")
+      issues = Autobot::Config::ConfigValidator.validate(config)
+
+      errors = issues.select { |i| i.severity == Autobot::Config::ValidatorCommon::Severity::Error }
+      errors.any?(&.message.includes?("Unknown transcription provider 'whisperx'")).should be_true
+    end
+
+    it "accepts a known transcription provider" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: groq\n")
+      issues = Autobot::Config::ConfigValidator.validate(config)
+
+      issues.any?(&.message.includes?("transcription provider")).should be_false
+    end
+  end
+
   describe "channel validation" do
     it "detects Telegram with empty allow_from" do
       config_yaml = <<-YAML

--- a/spec/autobot/transcriber_spec.cr
+++ b/spec/autobot/transcriber_spec.cr
@@ -27,6 +27,75 @@ describe Autobot::Transcriber do
     end
   end
 
+  describe ".source" do
+    it "prefers groq over openai when both chat providers have keys" do
+      config = Autobot::Config::Config.from_yaml("providers:\n  groq:\n    api_key: gsk\n  openai:\n    api_key: sk\n")
+
+      source = Autobot::Transcriber.source(config)
+      source.should_not be_nil
+      next unless source
+      source.provider.should eq("groq")
+      source.api_key.should eq("gsk")
+      source.own_key.should be_false
+    end
+
+    it "is nil when no chat provider can transcribe" do
+      Autobot::Transcriber.source(Autobot::Config::Config.from_yaml("providers:\n  anthropic:\n    api_key: ant\n")).should be_nil
+      Autobot::Transcriber.source(Autobot::Config::Config.from_yaml("{}")).should be_nil
+    end
+
+    it "is nil when transcription is disabled" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  enabled: false\nproviders:\n  groq:\n    api_key: gsk\n")
+
+      Autobot::Transcriber.source(config).should be_nil
+      Autobot::Transcriber.from_config(config).should be_nil
+    end
+
+    it "uses the pinned provider's chat key" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: openai\nproviders:\n  groq:\n    api_key: gsk\n  openai:\n    api_key: sk\n")
+
+      source = Autobot::Transcriber.source(config)
+      source.should_not be_nil
+      next unless source
+      source.provider.should eq("openai")
+      source.api_key.should eq("sk")
+    end
+
+    it "is nil when the pinned provider has no key" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: openai\nproviders:\n  groq:\n    api_key: gsk\n")
+
+      Autobot::Transcriber.source(config).should be_nil
+    end
+
+    it "uses its own key ahead of the chat providers" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  api_key: own\nproviders:\n  groq:\n    api_key: gsk\n")
+
+      source = Autobot::Transcriber.source(config)
+      source.should_not be_nil
+      next unless source
+      source.provider.should eq("openai")
+      source.api_key.should eq("own")
+      source.own_key.should be_true
+      Autobot::Transcriber.from_config(config).try(&.provider).should eq("openai")
+    end
+
+    it "pairs its own key with the pinned provider" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: groq\n  api_key: own\n")
+
+      source = Autobot::Transcriber.source(config)
+      source.should_not be_nil
+      next unless source
+      source.provider.should eq("groq")
+      source.api_key.should eq("own")
+    end
+
+    it "is nil for an unknown provider" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: whisperx\n  api_key: own\n")
+
+      Autobot::Transcriber.source(config).should be_nil
+    end
+  end
+
   describe "#transcribe" do
     it "returns nil for unknown provider" do
       t = Autobot::Transcriber.new(api_key: "test-key", provider: "unknown")

--- a/spec/autobot/transcriber_spec.cr
+++ b/spec/autobot/transcriber_spec.cr
@@ -27,72 +27,17 @@ describe Autobot::Transcriber do
     end
   end
 
-  describe ".source" do
-    it "prefers groq over openai when both chat providers have keys" do
-      config = Autobot::Config::Config.from_yaml("providers:\n  groq:\n    api_key: gsk\n  openai:\n    api_key: sk\n")
+  describe ".from_config" do
+    it "builds a transcriber for the resolved source" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: groq\n  api_key: own\n")
 
-      source = Autobot::Transcriber.source(config)
-      source.should_not be_nil
-      next unless source
-      source.provider.should eq("groq")
-      source.api_key.should eq("gsk")
-      source.own_key.should be_false
-    end
-
-    it "is nil when no chat provider can transcribe" do
-      Autobot::Transcriber.source(Autobot::Config::Config.from_yaml("providers:\n  anthropic:\n    api_key: ant\n")).should be_nil
-      Autobot::Transcriber.source(Autobot::Config::Config.from_yaml("{}")).should be_nil
+      Autobot::Transcriber.from_config(config).try(&.provider).should eq("groq")
     end
 
     it "is nil when transcription is disabled" do
       config = Autobot::Config::Config.from_yaml("transcription:\n  enabled: false\nproviders:\n  groq:\n    api_key: gsk\n")
 
-      Autobot::Transcriber.source(config).should be_nil
       Autobot::Transcriber.from_config(config).should be_nil
-    end
-
-    it "uses the pinned provider's chat key" do
-      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: openai\nproviders:\n  groq:\n    api_key: gsk\n  openai:\n    api_key: sk\n")
-
-      source = Autobot::Transcriber.source(config)
-      source.should_not be_nil
-      next unless source
-      source.provider.should eq("openai")
-      source.api_key.should eq("sk")
-    end
-
-    it "is nil when the pinned provider has no key" do
-      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: openai\nproviders:\n  groq:\n    api_key: gsk\n")
-
-      Autobot::Transcriber.source(config).should be_nil
-    end
-
-    it "uses its own key ahead of the chat providers" do
-      config = Autobot::Config::Config.from_yaml("transcription:\n  api_key: own\nproviders:\n  groq:\n    api_key: gsk\n")
-
-      source = Autobot::Transcriber.source(config)
-      source.should_not be_nil
-      next unless source
-      source.provider.should eq("openai")
-      source.api_key.should eq("own")
-      source.own_key.should be_true
-      Autobot::Transcriber.from_config(config).try(&.provider).should eq("openai")
-    end
-
-    it "pairs its own key with the pinned provider" do
-      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: groq\n  api_key: own\n")
-
-      source = Autobot::Transcriber.source(config)
-      source.should_not be_nil
-      next unless source
-      source.provider.should eq("groq")
-      source.api_key.should eq("own")
-    end
-
-    it "is nil for an unknown provider" do
-      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: whisperx\n  api_key: own\n")
-
-      Autobot::Transcriber.source(config).should be_nil
     end
   end
 

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -38,6 +38,7 @@ module Autobot::Agent
 
     GENERIC_ERROR_MESSAGE = "Sorry, I encountered an unexpected error. Please try again."
     FALLBACK_RESPONSE     = "I've completed processing but have no response to give."
+    VOICE_NOTE_NOT_HEARD  = "I could not hear that voice note. Voice transcription is not available here, so please type it instead."
 
     @running : Bool = false
     @cron_service : Cron::Service?
@@ -152,6 +153,7 @@ module Autobot::Agent
       return process_system_message(msg) if msg.channel == Constants::CHANNEL_SYSTEM
 
       log_incoming_message(msg)
+      return build_response(msg.channel, msg.chat_id, VOICE_NOTE_NOT_HEARD, msg.metadata) if msg.unheard_voice_note?
 
       session = @sessions.get_or_create(session_key || msg.session_key)
 

--- a/src/autobot/bus/events.cr
+++ b/src/autobot/bus/events.cr
@@ -5,8 +5,6 @@ module Autobot::Bus
   struct InboundMessage
     include JSON::Serializable
 
-    UNHEARD_VOICE_NOTE = "[voice message]"
-
     property channel : String
     property sender_id : String
     property chat_id : String
@@ -32,7 +30,7 @@ module Autobot::Bus
     end
 
     def unheard_voice_note? : Bool
-      content == UNHEARD_VOICE_NOTE && (media?.try(&.any?(&.sender_voice_note?)) || false)
+      media?.try(&.any? { |attachment| attachment.sender_voice_note? && !attachment.transcribed? }) == true
     end
   end
 
@@ -56,6 +54,7 @@ module Autobot::Bus
     property origin : String = ORIGIN_SENDER
     property transcript : String?
     property transcript_path : String?
+    property? transcribed : Bool = false
     property duration_seconds : Int32?
     property name : String?
 
@@ -72,6 +71,7 @@ module Autobot::Bus
       @origin : String = ORIGIN_SENDER,
       @transcript : String? = nil,
       @transcript_path : String? = nil,
+      @transcribed : Bool = !transcript.nil?,
       @duration_seconds : Int32? = nil,
       @name : String? = nil,
     )

--- a/src/autobot/bus/events.cr
+++ b/src/autobot/bus/events.cr
@@ -5,6 +5,8 @@ module Autobot::Bus
   struct InboundMessage
     include JSON::Serializable
 
+    UNHEARD_VOICE_NOTE = "[voice message]"
+
     property channel : String
     property sender_id : String
     property chat_id : String
@@ -27,6 +29,10 @@ module Autobot::Bus
     # Session key for persistence
     def session_key : String
       "#{channel}:#{chat_id}"
+    end
+
+    def unheard_voice_note? : Bool
+      content == UNHEARD_VOICE_NOTE && (media?.try(&.any?(&.sender_voice_note?)) || false)
     end
   end
 

--- a/src/autobot/channels/manager.cr
+++ b/src/autobot/channels/manager.cr
@@ -20,8 +20,6 @@ module Autobot::Channels
   class Manager
     Log = ::Log.for("channels.manager")
 
-    WHISPER_PROVIDERS = ["groq", "openai"]
-
     getter channels : Hash(String, Channel) = {} of String => Channel
     getter transcriber : Transcriber? = nil
     @inbox : Media::Inbox
@@ -91,23 +89,13 @@ module Autobot::Channels
     end
 
     private def detect_transcriber : Transcriber?
-      providers = @config.providers
-      return nil unless providers
-
-      WHISPER_PROVIDERS.each do |name|
-        provider = case name
-                   when "groq"   then providers.groq
-                   when "openai" then providers.openai
-                   else               nil
-                   end
-        if provider && !provider.api_key.empty?
-          Log.info { "Voice transcription enabled (#{name})" }
-          return Transcriber.new(api_key: provider.api_key, provider: name)
-        end
+      transcriber = Transcriber.from_config(@config)
+      if transcriber
+        Log.info { "Voice transcription enabled (#{transcriber.provider})" }
+      else
+        Log.info { "Voice transcription unavailable" }
       end
-
-      Log.info { "Voice transcription unavailable (no openai/groq provider)" }
-      nil
+      transcriber
     end
 
     private def init_channels : Nil

--- a/src/autobot/channels/telegram_media.cr
+++ b/src/autobot/channels/telegram_media.cr
@@ -11,7 +11,7 @@ module Autobot::Channels
     alias Fetcher = Proc(String, Bytes?)
 
     FORWARD_KEYS  = %w[forward_origin forward_from forward_from_chat forward_sender_name forward_date]
-    VOICE_MISSING = "[voice message]"
+    VOICE_MISSING = Bus::InboundMessage::UNHEARD_VOICE_NOTE
 
     def initialize(@fetch : Fetcher, @transcriber : Transcriber? = nil, @inbox : Media::Inbox? = nil)
     end

--- a/src/autobot/channels/telegram_media.cr
+++ b/src/autobot/channels/telegram_media.cr
@@ -11,7 +11,7 @@ module Autobot::Channels
     alias Fetcher = Proc(String, Bytes?)
 
     FORWARD_KEYS  = %w[forward_origin forward_from forward_from_chat forward_sender_name forward_date]
-    VOICE_MISSING = Bus::InboundMessage::UNHEARD_VOICE_NOTE
+    VOICE_MISSING = "[voice message]"
 
     def initialize(@fetch : Fetcher, @transcriber : Transcriber? = nil, @inbox : Media::Inbox? = nil)
     end
@@ -51,7 +51,7 @@ module Autobot::Channels
       format = format_of(voice, Bus::MediaAttachment::TYPE_VOICE, "audio/ogg")
       transcript = transcribe(bytes, format[0])
       attachment = build(Bus::MediaAttachment::TYPE_VOICE, voice, origin, format, bytes,
-        transcript: spoken ? nil : transcript)
+        transcript: spoken ? nil : transcript, transcribed: !transcript.nil?)
       {attachment, spoken ? spoken_text(transcript) : nil}
     end
 
@@ -87,7 +87,8 @@ module Autobot::Channels
     end
 
     private def build(type : String, node : JSON::Any, origin : String, format : {String, String}, bytes : Bytes?,
-                      data : String? = nil, transcript : String? = nil, name : String? = nil) : Bus::MediaAttachment
+                      data : String? = nil, transcript : String? = nil, transcribed : Bool = !transcript.nil?,
+                      name : String? = nil) : Bus::MediaAttachment
       extension, mime = format
       path = bytes.try { |content| @inbox.try(&.store(content, extension)) }
       transcript_path = transcript && path ? @inbox.try(&.store_transcript(transcript, path)) : nil
@@ -102,6 +103,7 @@ module Autobot::Channels
         origin: origin,
         transcript: transcript,
         transcript_path: transcript_path.try(&.to_s),
+        transcribed: transcribed,
         duration_seconds: node["duration"]?.try(&.as_i?),
         name: name,
       )

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -407,8 +407,9 @@ module Autobot
       def self.check_voice_transcription(config : Config::Config) : Nil
         transcription = config.transcription
         return report(Status::Skip, "Voice transcription disabled") unless transcription.enabled?
+        return report(Status::Fail, "Unknown transcription provider '#{transcription.provider}'") unless transcription.provider_known?
 
-        if source = Transcriber.source(config)
+        if source = config.transcription_source
           key_note = source.own_key ? ", own key" : ""
           return report(Status::Pass, "Voice transcription available (#{source.provider}#{key_note})")
         end

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -405,25 +405,20 @@ module Autobot
       end
 
       def self.check_voice_transcription(config : Config::Config) : Nil
-        providers = config.providers
-        unless providers
+        transcription = config.transcription
+        return report(Status::Skip, "Voice transcription disabled") unless transcription.enabled?
+
+        if source = Transcriber.source(config)
+          key_note = source.own_key ? ", own key" : ""
+          return report(Status::Pass, "Voice transcription available (#{source.provider}#{key_note})")
+        end
+
+        if provider = transcription.provider
+          report(Status::Warn, "Voice transcription enabled but no api key for #{provider}")
+          hint("Set transcription.api_key or providers.#{provider}.api_key")
+        else
           report(Status::Skip, "Voice transcription (no openai/groq provider)")
-          return
         end
-
-        Channels::Manager::WHISPER_PROVIDERS.each do |name|
-          provider = case name
-                     when "groq"   then providers.groq
-                     when "openai" then providers.openai
-                     else               nil
-                     end
-          if provider && !provider.api_key.empty?
-            report(Status::Pass, "Voice transcription available (#{name})")
-            return
-          end
-        end
-
-        report(Status::Skip, "Voice transcription (no openai/groq provider)")
       end
 
       def self.check_image_generation(config : Config::Config) : Nil

--- a/src/autobot/config/config_validator.cr
+++ b/src/autobot/config/config_validator.cr
@@ -1,6 +1,5 @@
 require "./schema"
 require "./validator_common"
-require "../transcriber"
 
 module Autobot::Config
   # Configuration validator
@@ -22,12 +21,11 @@ module Autobot::Config
 
     private def self.check_transcription(config : Config) : Array(Issue)
       issues = [] of Issue
-      provider = config.transcription.provider
-      return issues if provider.nil? || Transcriber::PROVIDERS.has_key?(provider)
+      return issues if config.transcription.provider_known?
 
       issues << Issue.new(
         severity: Severity::Error,
-        message: "Unknown transcription provider '#{provider}'. Use one of: #{Transcriber::PROVIDERS.keys.join(", ")}."
+        message: "Unknown transcription provider '#{config.transcription.provider}'. Use one of: #{TranscriptionConfig::PROVIDERS.join(", ")}."
       )
       issues
     end

--- a/src/autobot/config/config_validator.cr
+++ b/src/autobot/config/config_validator.cr
@@ -1,5 +1,6 @@
 require "./schema"
 require "./validator_common"
+require "../transcriber"
 
 module Autobot::Config
   # Configuration validator
@@ -14,7 +15,20 @@ module Autobot::Config
       issues.concat(check_provider_config(config))
       issues.concat(check_channel_auth(config))
       issues.concat(check_gateway_binding(config))
+      issues.concat(check_transcription(config))
 
+      issues
+    end
+
+    private def self.check_transcription(config : Config) : Array(Issue)
+      issues = [] of Issue
+      provider = config.transcription.provider
+      return issues if provider.nil? || Transcriber::PROVIDERS.has_key?(provider)
+
+      issues << Issue.new(
+        severity: Severity::Error,
+        message: "Unknown transcription provider '#{provider}'. Use one of: #{Transcriber::PROVIDERS.keys.join(", ")}."
+      )
       issues
     end
 

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -316,6 +316,12 @@ module Autobot::Config
 
   class TranscriptionConfig
     include YAML::Serializable
+
+    PROVIDERS        = %w[groq openai]
+    DEFAULT_PROVIDER = "openai"
+
+    record Source, provider : String, api_key : String, own_key : Bool
+
     property? enabled : Bool = true
     property provider : String? = nil
     property api_key : String? = nil
@@ -324,7 +330,13 @@ module Autobot::Config
     end
 
     def own_key : String?
-      api_key.presence
+      key = api_key
+      key if key && !key.empty? && !key.includes?("${")
+    end
+
+    def provider_known? : Bool
+      name = provider
+      name.nil? || PROVIDERS.includes?(name)
     end
   end
 
@@ -426,6 +438,21 @@ module Autobot::Config
 
     def inbox_path : Path
       Path[media.inbox].expand(base: workspace_path, home: true)
+    end
+
+    def transcription_source : TranscriptionConfig::Source?
+      return nil unless transcription.enabled?
+
+      pinned = transcription.provider
+      if own_key = transcription.own_key
+        return TranscriptionConfig::Source.new(pinned || TranscriptionConfig::DEFAULT_PROVIDER, own_key, own_key: true)
+      end
+
+      (pinned ? [pinned] : TranscriptionConfig::PROVIDERS).each do |name|
+        key = provider_by_name(name).try(&.api_key.presence)
+        return TranscriptionConfig::Source.new(name, key, own_key: false) if key
+      end
+      nil
     end
 
     def default_model : String

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -314,6 +314,20 @@ module Autobot::Config
     end
   end
 
+  class TranscriptionConfig
+    include YAML::Serializable
+    property? enabled : Bool = true
+    property provider : String? = nil
+    property api_key : String? = nil
+
+    def initialize
+    end
+
+    def own_key : String?
+      api_key.presence
+    end
+  end
+
   class CronConfig
     include YAML::Serializable
     property? enabled : Bool = true
@@ -400,6 +414,7 @@ module Autobot::Config
     property mcp : McpConfig?
     property plugins : PluginsConfig?
     property media : MediaConfig = MediaConfig.new
+    property transcription : TranscriptionConfig = TranscriptionConfig.new
 
     def initialize
     end

--- a/src/autobot/transcriber.cr
+++ b/src/autobot/transcriber.cr
@@ -24,47 +24,13 @@ module Autobot
 
     BOUNDARY = "----AutobotWhisperBoundary"
 
-    DEFAULT_PROVIDER = "openai"
-    PROVIDER_ORDER   = ["groq", "openai"]
-
-    record Source, provider : String, api_key : String, own_key : Bool
-
     getter provider : String
 
-    def initialize(@api_key : String, @provider : String = DEFAULT_PROVIDER)
+    def initialize(@api_key : String, @provider : String = "openai")
     end
 
     def self.from_config(config : Config::Config) : Transcriber?
-      source(config).try { |found| new(api_key: found.api_key, provider: found.provider) }
-    end
-
-    def self.source(config : Config::Config) : Source?
-      transcription = config.transcription
-      return nil unless transcription.enabled?
-
-      pinned = transcription.provider
-      return nil if pinned && !PROVIDERS.has_key?(pinned)
-      if own_key = transcription.own_key
-        return Source.new(pinned || DEFAULT_PROVIDER, own_key, own_key: true)
-      end
-
-      candidates = pinned ? [pinned] : PROVIDER_ORDER
-      candidates.each do |name|
-        key = provider_key(config, name)
-        return Source.new(name, key, own_key: false) if key
-      end
-      nil
-    end
-
-    private def self.provider_key(config : Config::Config, name : String) : String?
-      providers = config.providers
-      return nil unless providers
-
-      provider = case name
-                 when "groq"   then providers.groq
-                 when "openai" then providers.openai
-                 end
-      provider.try(&.api_key.presence)
+      config.transcription_source.try { |source| new(api_key: source.api_key, provider: source.provider) }
     end
 
     # Transcribe audio data to text.

--- a/src/autobot/transcriber.cr
+++ b/src/autobot/transcriber.cr
@@ -1,5 +1,6 @@
 require "http/client"
 require "json"
+require "./config/schema"
 
 module Autobot
   # Speech-to-text transcription via Whisper API (OpenAI or Groq).
@@ -23,9 +24,47 @@ module Autobot
 
     BOUNDARY = "----AutobotWhisperBoundary"
 
+    DEFAULT_PROVIDER = "openai"
+    PROVIDER_ORDER   = ["groq", "openai"]
+
+    record Source, provider : String, api_key : String, own_key : Bool
+
     getter provider : String
 
-    def initialize(@api_key : String, @provider : String = "openai")
+    def initialize(@api_key : String, @provider : String = DEFAULT_PROVIDER)
+    end
+
+    def self.from_config(config : Config::Config) : Transcriber?
+      source(config).try { |found| new(api_key: found.api_key, provider: found.provider) }
+    end
+
+    def self.source(config : Config::Config) : Source?
+      transcription = config.transcription
+      return nil unless transcription.enabled?
+
+      pinned = transcription.provider
+      return nil if pinned && !PROVIDERS.has_key?(pinned)
+      if own_key = transcription.own_key
+        return Source.new(pinned || DEFAULT_PROVIDER, own_key, own_key: true)
+      end
+
+      candidates = pinned ? [pinned] : PROVIDER_ORDER
+      candidates.each do |name|
+        key = provider_key(config, name)
+        return Source.new(name, key, own_key: false) if key
+      end
+      nil
+    end
+
+    private def self.provider_key(config : Config::Config, name : String) : String?
+      providers = config.providers
+      return nil unless providers
+
+      provider = case name
+                 when "groq"   then providers.groq
+                 when "openai" then providers.openai
+                 end
+      provider.try(&.api_key.presence)
     end
 
     # Transcribe audio data to text.


### PR DESCRIPTION
## Overview

- [x] `transcription.enabled`, `transcription.provider` and `transcription.api_key` in the config schema, default unchanged (groq, then openai chat key)
- [x] the transcription source is resolved on the config through the existing provider lookup, shared by the channel manager and doctor
- [x] a voice note nobody could hear is flagged on the attachment and gets a fixed reply from the agent loop, no model turn
- [x] doctor shows the provider, notes an own key, warns when a pinned provider has no key, fails on an unknown one; validator rejects unknown providers
- [x] specs for on, off, pinned provider, own key, unexpanded keys, doctor output and the fixed reply
- [x] docs: configuration reference, media guide, Telegram page, security guide