### PR TITLE
Bump v0.8.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: autobot
-version: 0.7.2
+version: 0.8.0
 
 authors:
   - Vitalii Elenhaupt


### PR DESCRIPTION
- [x] shard.yml version 0.7.2 -> 0.8.0

Release notes are prepared separately for the v0.8.0 tag.