### PR TITLE
chore: cleanup before the 0.8.0 release

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ tools:
     - edit_file
     - list_dir
     - message
-    - "ha_*"     # patterns ending in * match by prefix (skills, plugins, MCP tools)
+    - "mcp_homeassistant_*"  # a trailing * matches by prefix; MCP tools are named mcp_<server>_<tool>
   filesystem:
     roots: [notes, inbox]  # Optional; file tools may only touch these workspace subdirectories
   sandbox: auto  # auto | bubblewrap | docker | none (default: auto)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,6 +197,7 @@ autobot doctor --strict # Fail on any warning (CI/CD)
 - `.env` permissions (must be 0600)
 - `.env` inside workspace (exposes secrets)
 - No LLM provider configured
+- Unknown transcription provider
 
 **⚠️ Warnings** (review recommended):
 
@@ -204,6 +205,7 @@ autobot doctor --strict # Fail on any warning (CI/CD)
 - Empty channel allowlists
 - Missing `.env` file
 - Workspace restrictions disabled
+- Voice transcription pinned to a provider that has no api key
 
 ---
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -321,10 +321,11 @@ Run `autobot doctor` to check voice transcription status:
 ✓ Voice transcription available (openai, own key)
 ```
 
-Or when it is off, or no provider is configured:
+Or when it is off, no provider is configured, or the config names a provider it does not know:
 
 ```
 — Voice transcription disabled
 — Voice transcription (no openai/groq provider)
 ! Voice transcription enabled but no api key for openai
+✗ Unknown transcription provider 'whisperx'
 ```

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -61,7 +61,7 @@ Voice messages are automatically transcribed when a supported provider is config
 - **Groq** (preferred) — uses `whisper-large-v3-turbo`, faster with free tier
 - **OpenAI** — uses `whisper-1`
 
-If neither is configured, voice messages fall back to `[voice message]` text. Transcription works regardless of which provider you use for chat — you can use DeepSeek for chat and Groq for voice transcription by configuring both.
+If neither is configured, the bot replies that it could not hear the voice note instead of sending it to the model; see [Voice transcription](configuration.md#voice-transcription) for the per-bot settings. Transcription works regardless of which provider you use for chat — you can use DeepSeek for chat and Groq for voice transcription by configuring both.
 
 ## Multiple providers
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -157,11 +157,13 @@ autobot doctor --strict # Fail on any warning (CI/CD)
 - `.env` file permissions not 0600
 - `.env` file inside workspace directory
 - No LLM provider configured
+- Unknown transcription provider
 
 **⚠️ Warnings (review recommended):**
 
 - Filesystem root configured outside the workspace
 - `tools.enabled` entry that matches no known tool
+- Voice transcription pinned to a provider that has no api key
 - Gateway bound to 0.0.0.0 (network exposure)
 - Channel authorization not configured (empty `allow_from`)
 - Missing `.env` file

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -139,4 +139,4 @@ LOG_LEVEL=DEBUG autobot agent
 
 **"Telegram bot token not configured"** — token is empty. Check `.env` file and `${TELEGRAM_BOT_TOKEN}` substitution.
 
-**Voice messages show `[voice message]`** — no Whisper provider configured. Add Groq or OpenAI provider.
+**Bot replies that it could not hear a voice note** — transcription is off or no Whisper key is available. Add a Groq or OpenAI provider, or set `transcription.api_key`; see [Voice transcription](configuration.md#voice-transcription). `autobot doctor` shows which provider is in use.

--- a/spec/autobot/channels/whatsapp_spec.cr
+++ b/spec/autobot/channels/whatsapp_spec.cr
@@ -10,8 +10,12 @@ class WhatsAppChannelTest < Autobot::Channels::WhatsAppChannel
     resolve_sender_id(data, sender)
   end
 
-  def test_build_content(data : JSON::Any, sender_id : String) : String
-    build_content(data, sender_id)
+  def test_build_content(data : JSON::Any) : String
+    build_content(data)
+  end
+
+  def test_build_media(data : JSON::Any) : Array(Autobot::Bus::MediaAttachment)?
+    build_media(data)
   end
 
   def test_build_metadata(data : JSON::Any) : Hash(String, String)
@@ -84,23 +88,35 @@ describe Autobot::Channels::WhatsAppChannel do
     end
   end
 
+  describe "#build_media" do
+    it "marks a voice note as an unheard sender voice note" do
+      channel = build_whatsapp_channel
+      media = channel.test_build_media(JSON.parse(%({"content": "[Voice Message]"})))
+
+      media.try(&.size).should eq(1)
+      message = Autobot::Bus::InboundMessage.new(channel: "whatsapp", sender_id: "u", chat_id: "c", content: "[Voice Message]", media: media)
+      message.unheard_voice_note?.should be_true
+      channel.test_build_media(JSON.parse(%({"content": "hello"}))).should be_nil
+    end
+  end
+
   describe "#build_content" do
     it "returns plain text content" do
       data = JSON.parse(%({"content": "hello world"}))
       channel = build_whatsapp_channel
-      channel.test_build_content(data, "user1").should eq("hello world")
+      channel.test_build_content(data).should eq("hello world")
     end
 
-    it "replaces voice message placeholder" do
+    it "keeps the bridge placeholder for a voice note" do
       data = JSON.parse(%({"content": "[Voice Message]"}))
       channel = build_whatsapp_channel
-      channel.test_build_content(data, "user1").should contain("Transcription not available")
+      channel.test_build_content(data).should eq("[Voice Message]")
     end
 
     it "prepends reply context when quoted is present" do
       data = JSON.parse(%({"content": "yes please", "quoted": "Should I continue?"}))
       channel = build_whatsapp_channel
-      result = channel.test_build_content(data, "user1")
+      result = channel.test_build_content(data)
       result.should contain("[Replying to: \"Should I continue?\"]")
       result.should contain("yes please")
     end
@@ -108,7 +124,7 @@ describe Autobot::Channels::WhatsAppChannel do
     it "returns empty string when content is missing" do
       data = JSON.parse(%({}))
       channel = build_whatsapp_channel
-      channel.test_build_content(data, "user1").should eq("")
+      channel.test_build_content(data).should eq("")
     end
   end
 

--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -370,7 +370,7 @@ describe Autobot::CLI::Doctor do
       config = make_config("{}")
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(0)
 
         io.to_s.should contain("— Voice transcription (no openai/groq provider)")
       end
@@ -385,7 +385,7 @@ describe Autobot::CLI::Doctor do
       )
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(0)
 
         io.to_s.should contain("✓ Voice transcription available (groq)")
       end
@@ -400,7 +400,7 @@ describe Autobot::CLI::Doctor do
       )
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(0)
 
         io.to_s.should contain("✓ Voice transcription available (openai)")
       end
@@ -417,7 +417,7 @@ describe Autobot::CLI::Doctor do
       )
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(0)
 
         io.to_s.should contain("— Voice transcription disabled")
       end
@@ -432,7 +432,7 @@ describe Autobot::CLI::Doctor do
       )
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(0)
 
         io.to_s.should contain("✓ Voice transcription available (groq, own key)")
       end
@@ -442,7 +442,7 @@ describe Autobot::CLI::Doctor do
       config = make_config("transcription:\n  provider: whisperx\n")
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(1)
 
         io.to_s.should contain("✗ Unknown transcription provider 'whisperx'")
       end
@@ -459,7 +459,7 @@ describe Autobot::CLI::Doctor do
       )
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(0)
 
         io.to_s.should contain("! Voice transcription enabled but no api key for openai")
         io.to_s.should contain("transcription.api_key or providers.openai.api_key")
@@ -477,7 +477,7 @@ describe Autobot::CLI::Doctor do
       )
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(0)
 
         io.to_s.should contain("✓ Voice transcription available (groq)")
       end
@@ -492,7 +492,7 @@ describe Autobot::CLI::Doctor do
       )
 
       with_doctor_io do |io|
-        Autobot::CLI::Doctor.check_voice_transcription(config)
+        Autobot::CLI::Doctor.check_voice_transcription(config, 0).should eq(0)
 
         io.to_s.should contain("— Voice transcription (no openai/groq provider)")
       end

--- a/src/autobot/channels/whatsapp.cr
+++ b/src/autobot/channels/whatsapp.cr
@@ -11,7 +11,7 @@ module Autobot::Channels
   #
   # Features:
   # - QR code authentication (displayed in bridge terminal)
-  # - Message handling (text, voice message notices)
+  # - Message handling (text, voice notes as attachments)
   # - Connection state management
   # - Auto-reconnection with backoff
   # - Allow list for access control
@@ -19,6 +19,7 @@ module Autobot::Channels
     Log = ::Log.for("channels.whatsapp")
 
     RECONNECT_DELAY = 5
+    VOICE_MESSAGE   = "[Voice Message]"
 
     @connected : Bool = false
 
@@ -114,12 +115,11 @@ module Autobot::Channels
     private def handle_incoming_message(data : JSON::Any) : Nil
       sender = data["sender"]?.try(&.as_s) || ""
       sender_id = resolve_sender_id(data, sender)
-      content = build_content(data, sender_id)
-
       handle_message(
         sender_id: sender_id,
         chat_id: sender,
-        content: content,
+        content: build_content(data),
+        media: build_media(data),
         metadata: build_metadata(data),
       )
     end
@@ -130,15 +130,14 @@ module Autobot::Channels
       user_id.includes?('@') ? user_id.split('@').first : user_id
     end
 
-    private def build_content(data : JSON::Any, sender_id : String) : String
+    private def build_content(data : JSON::Any) : String
       content = data["content"]?.try(&.as_s) || ""
-
-      if content == "[Voice Message]"
-        Log.info { "Voice message from #{sender_id} (transcription not yet supported)" }
-        content = "[Voice Message: Transcription not available for WhatsApp yet]"
-      end
-
       prepend_reply_context(content, extract_reply_context(data))
+    end
+
+    private def build_media(data : JSON::Any) : Array(Bus::MediaAttachment)?
+      return nil unless data["content"]?.try(&.as_s?) == VOICE_MESSAGE
+      [Bus::MediaAttachment.new(type: Bus::MediaAttachment::TYPE_VOICE)]
     end
 
     private def build_metadata(data : JSON::Any) : Hash(String, String)

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -84,7 +84,7 @@ module Autobot
         warnings = check_channels(config, warnings)
 
         # Voice transcription
-        check_voice_transcription(config)
+        errors = check_voice_transcription(config, errors)
 
         # Image generation
         check_image_generation(config)
@@ -404,10 +404,21 @@ module Autobot
         end
       end
 
-      def self.check_voice_transcription(config : Config::Config) : Nil
+      def self.check_voice_transcription(config : Config::Config, errors : Int32) : Int32
+        transcription = config.transcription
+        unless transcription.provider_known?
+          report(Status::Fail, "Unknown transcription provider '#{transcription.provider}'")
+          hint("Use one of: #{Config::TranscriptionConfig::PROVIDERS.join(", ")}")
+          return errors + 1
+        end
+
+        report_transcription_status(config)
+        errors
+      end
+
+      private def self.report_transcription_status(config : Config::Config) : Nil
         transcription = config.transcription
         return report(Status::Skip, "Voice transcription disabled") unless transcription.enabled?
-        return report(Status::Fail, "Unknown transcription provider '#{transcription.provider}'") unless transcription.provider_known?
 
         if source = config.transcription_source
           key_note = source.own_key ? ", own key" : ""


### PR DESCRIPTION
## Overview

- [x] WhatsApp voice notes arrive as attachments, so the fixed "could not hear" reply covers WhatsApp too and the channel-specific notice is gone
- [x] doctor counts an unknown transcription provider as an error instead of only printing one
- [x] doctor error and warning lists in the security, deployment and media docs include the transcription messages
- [x] providers and Telegram pages describe the fixed reply instead of the old placeholder text
- [x] allowlist example uses a real MCP tool pattern (`mcp_<server>_<tool>`)