### PR TITLE
fix(mcp): union types in tool schemas and prefixed names in doctor

### DIFF
--- a/spec/autobot/cli/doctor_spec.cr
+++ b/spec/autobot/cli/doctor_spec.cr
@@ -641,7 +641,7 @@ describe Autobot::CLI::Doctor do
         defaults:
           workspace: "#{workspace}"
       tools:
-        enabled: [bash_deploy, get_weather, ha_get_*, read_file]
+        enabled: [bash_deploy, get_weather, mcp_homeassistant_ha_get_*, mcp_homeassistant_ha_call_service, read_file]
       mcp:
         servers:
           homeassistant:

--- a/spec/autobot/mcp/proxy_tool_spec.cr
+++ b/spec/autobot/mcp/proxy_tool_spec.cr
@@ -136,6 +136,23 @@ describe Autobot::Mcp::ProxyTool do
       schema.properties["x"].type.should eq("string")
     end
 
+    it "uses the concrete type of a nullable property" do
+      raw = JSON.parse(%({"type":"object","properties":{"limit":{"anyOf":[{"type":"integer"},{"type":"null"}]},"name":{"type":["string","null"]}}}))
+      schema = Autobot::Mcp::ProxyTool.convert_schema(raw)
+      schema.properties["limit"].type.should eq("integer")
+      schema.properties["name"].type.should eq("string")
+    end
+
+    it "accepts any value for a union of several types" do
+      raw = JSON.parse(%({"type":"object","properties":{"domains":{"anyOf":[{"type":"string"},{"type":"array","items":{"type":"string"}},{"type":"null"}]}}}))
+      schema = Autobot::Mcp::ProxyTool.convert_schema(raw)
+      property = schema.properties["domains"]
+      property.untyped?.should be_true
+      property.validate(JSON.parse(%(["light","sensor"])), "domains").should be_empty
+      property.validate(JSON.parse(%("light")), "domains").should be_empty
+      property.to_json_any.as_h.has_key?("type").should be_false
+    end
+
     it "handles array type with items" do
       raw = JSON.parse(%({"type":"object","properties":{"ids":{"type":"array","items":{"type":"integer"}}}}))
       schema = Autobot::Mcp::ProxyTool.convert_schema(raw)

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -1,5 +1,6 @@
 require "../config/validator"
 require "../tools/sandbox"
+require "../mcp/proxy_tool"
 
 module Autobot
   module CLI
@@ -218,7 +219,8 @@ module Autobot
       end
 
       private def self.mcp_tool_patterns(config : Config::Config) : Array(String)
-        config.mcp.try(&.servers.values.flat_map(&.tools)) || [] of String
+        servers = config.mcp.try(&.servers) || {} of String => Config::McpServerConfig
+        servers.flat_map { |name, server| server.tools.map { |tool| Mcp::ProxyTool.build_name(name, tool) } }
       end
 
       private def self.mcp_servers_without_tool_list?(config : Config::Config) : Bool

--- a/src/autobot/mcp/proxy_tool.cr
+++ b/src/autobot/mcp/proxy_tool.cr
@@ -123,8 +123,7 @@ module Autobot
       end
 
       private def self.convert_property(prop : JSON::Any) : Tools::PropertySchema
-        type = prop["type"]?.try(&.as_s?) || "string"
-        type = "string" unless Tools::Tool::VALID_SCHEMA_TYPES.includes?(type)
+        type = resolve_type(prop)
         desc = prop["description"]?.try(&.as_s?) || ""
 
         enum_values = prop["enum"]?.try(&.as_a?.try(&.compact_map(&.as_s?)))
@@ -139,6 +138,24 @@ module Autobot
           enum_values: enum_values,
           items: items,
         )
+      end
+
+      private def self.resolve_type(prop : JSON::Any) : String
+        types = declared_types(prop).select { |type| Tools::Tool::VALID_SCHEMA_TYPES.includes?(type) }.uniq!
+        case types.size
+        when 0 then "string"
+        when 1 then types.first
+        else        Tools::PropertySchema::ANY
+        end
+      end
+
+      private def self.declared_types(prop : JSON::Any) : Array(String)
+        if type = prop["type"]?
+          return [type.as_s] if type.as_s?
+          return type.as_a.compact_map(&.as_s?) if type.as_a?
+        end
+        branches = prop["anyOf"]? || prop["oneOf"]?
+        branches.try(&.as_a?).try(&.flat_map { |branch| declared_types(branch) }) || [] of String
       end
     end
   end

--- a/src/autobot/tools/base.cr
+++ b/src/autobot/tools/base.cr
@@ -92,6 +92,8 @@ module Autobot
 
     # Describes a single property in a tool's parameter schema.
     class PropertySchema
+      ANY = "any"
+
       getter type : String
       getter description : String
       getter enum_values : Array(String)?
@@ -132,6 +134,10 @@ module Autobot
         else
           [] of String
         end
+      end
+
+      def untyped? : Bool
+        @type == ANY
       end
 
       private def validate_string(value : JSON::Any, path : String) : Array(String)
@@ -212,7 +218,7 @@ module Autobot
 
       def to_json_any : JSON::Any
         obj = {} of String => JSON::Any
-        obj["type"] = JSON::Any.new(@type)
+        obj["type"] = JSON::Any.new(@type) unless untyped?
         obj["description"] = JSON::Any.new(@description) unless @description.empty?
 
         if ev = @enum_values


### PR DESCRIPTION
## Overview

- [x] MCP tool properties declared as a type list or through anyOf/oneOf keep their concrete type when nullable, and accept any value when they are a real union; before, they collapsed to string and valid calls failed validation
- [x] doctor compares allowlist entries with the registered `mcp_<server>_<tool>` names instead of the bare server tool names