### PR TITLE
feat(telegram): own the General topic as topic 1

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -143,7 +143,7 @@ channels:
 ```
 
 - The topic ID is the number at the end of the topic link, `https://t.me/c/<group>/57`.
-- Messages in a listed topic are treated as addressed to the bot; other topics and the General topic still need a mention.
+- Messages in a listed topic are treated as addressed to the bot; other topics still need a mention. The General topic is topic 1: `topics: [1]` gives a bot the General topic, and replies there carry no thread id, as Telegram expects.
 - The chat ID becomes `<group>:<topic>`, for example `-1001234567890:57`, so each topic has its own session, its own `/reset` and its own cron delivery target. Use that form as the `to` of a cron job or a message tool call to reach a topic.
 - The bot must see the topic's messages: turn off privacy mode for it in BotFather (`/setprivacy`), or make it a group admin, then remove and re-add it to the group.
 

--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -155,8 +155,9 @@ private def build_channel(
   )
 end
 
-private TOPIC_MESSAGE = %({"message_id": 9, "message_thread_id": 57, "is_topic_message": true, "chat": {"id": -1001, "type": "supergroup"}, "from": {"id": 1, "first_name": "Ann"}, "text": "hi"})
-private GENERAL_REPLY = %({"message_id": 9, "message_thread_id": 3, "chat": {"id": -1001, "type": "supergroup"}, "from": {"id": 1, "first_name": "Ann"}, "text": "hi"})
+private TOPIC_MESSAGE   = %({"message_id": 9, "message_thread_id": 57, "is_topic_message": true, "chat": {"id": -1001, "type": "supergroup"}, "from": {"id": 1, "first_name": "Ann"}, "text": "hi"})
+private GENERAL_REPLY   = %({"message_id": 9, "message_thread_id": 3, "chat": {"id": -1001, "type": "supergroup"}, "from": {"id": 1, "first_name": "Ann"}, "text": "hi"})
+private GENERAL_MESSAGE = %({"message_id": 9, "chat": {"id": -1001, "type": "supergroup", "is_forum": true}, "from": {"id": 1, "first_name": "Ann"}, "text": "hi"})
 
 describe Autobot::Channels::TelegramChannel do
   describe "forum topics" do
@@ -166,6 +167,14 @@ describe Autobot::Channels::TelegramChannel do
       sender.try(&.[:chat_id]).should eq("-1001:57")
       sender.try(&.[:topic]).should eq(57)
       channel.test_extract_sender(JSON.parse(GENERAL_REPLY)).try(&.[:chat_id]).should eq("-1001")
+      channel.test_extract_sender(JSON.parse(GENERAL_MESSAGE)).try(&.[:chat_id]).should eq("-1001:1")
+    end
+
+    it "owns the General topic of a forum as topic 1" do
+      channel = TelegramChannelTest.new(bus: Autobot::Bus::MessageBus.new, token: "t", topics: [1_i64])
+      channel.test_addressed?(JSON.parse(GENERAL_MESSAGE)).should be_true
+      channel.test_addressed?(JSON.parse(TOPIC_MESSAGE)).should be_false
+      channel.test_chat_params("-1001:1").should eq({"chat_id" => "-1001"})
     end
 
     it "answers in its own topics without a mention and stays silent elsewhere" do

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -295,6 +295,7 @@ module Autobot::Channels
 
     TELEGRAM_API_BASE = "https://api.telegram.org"
     TOPIC_SEPARATOR   = ':'
+    GENERAL_TOPIC     = 1_i64
 
     alias Sender = NamedTuple(chat_id: String, user_id: String, username: String?, first_name: String, sender_id: String, is_group: Bool, topic: Int64?)
     POLL_TIMEOUT    =  30
@@ -618,6 +619,7 @@ module Autobot::Channels
       return nil unless chat && from
 
       topic = msg["message_thread_id"]?.try(&.as_i64?) if msg["is_topic_message"]?.try(&.as_bool?)
+      topic ||= GENERAL_TOPIC if chat["is_forum"]?.try(&.as_bool?)
       chat_id = topic ? "#{chat["id"].as_i64}#{TOPIC_SEPARATOR}#{topic}" : chat["id"].as_i64.to_s
       user_id = from["id"].as_i64.to_s
       username = from["username"]?.try(&.as_s)
@@ -1090,7 +1092,7 @@ module Autobot::Channels
     private def chat_params(chat_id : String) : Hash(String, String)
       chat, _, topic = chat_id.partition(TOPIC_SEPARATOR)
       params = {"chat_id" => chat}
-      params["message_thread_id"] = topic unless topic.empty?
+      params["message_thread_id"] = topic unless topic.empty? || topic == GENERAL_TOPIC.to_s
       params
     end
 


### PR DESCRIPTION
## Overview

- [x] a message in the General topic of a forum supergroup gets topic 1, so `topics: [1]` lets a bot answer there without a mention and gives General its own session and cron target
- [x] requests to `<group>:1` carry no `message_thread_id`, as Telegram expects for General
- [x] service messages (a member joining, a pinned message, a topic created) are ignored instead of being answered as empty messages
- [x] docs explain that General is topic 1 and that service messages are skipped