### PR TITLE
fix(telegram): ignore service messages

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -146,6 +146,7 @@ channels:
 - Messages in a listed topic are treated as addressed to the bot; other topics still need a mention. The General topic is topic 1: `topics: [1]` gives a bot the General topic, and replies there carry no thread id, as Telegram expects.
 - The chat ID becomes `<group>:<topic>`, for example `-1001234567890:57`, so each topic has its own session, its own `/reset` and its own cron delivery target. Use that form as the `to` of a cron job or a message tool call to reach a topic.
 - The bot must see the topic's messages: turn off privacy mode for it in BotFather (`/setprivacy`), or make it a group admin, then remove and re-add it to the group.
+- Service messages, such as a member joining, a pinned message or a topic being created, are ignored, so owning a topic never makes the bot comment on them.
 
 ## Troubleshooting
 

--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -40,6 +40,10 @@ class TelegramChannelTest < Autobot::Channels::TelegramChannel
     extract_sender(msg)
   end
 
+  def test_service_message?(msg : JSON::Any) : Bool
+    service_message?(msg)
+  end
+
   def test_addressed?(msg : JSON::Any) : Bool
     sender = extract_sender(msg)
     sender ? addressed?(msg, sender) : false
@@ -168,6 +172,16 @@ describe Autobot::Channels::TelegramChannel do
       sender.try(&.[:topic]).should eq(57)
       channel.test_extract_sender(JSON.parse(GENERAL_REPLY)).try(&.[:chat_id]).should eq("-1001")
       channel.test_extract_sender(JSON.parse(GENERAL_MESSAGE)).try(&.[:chat_id]).should eq("-1001:1")
+    end
+
+    it "ignores service messages such as a member joining or a topic being created" do
+      channel = TelegramChannelTest.new(bus: Autobot::Bus::MessageBus.new, token: "t", topics: [1_i64])
+      joined = %({"message_id": 10, "chat": {"id": -1001, "type": "supergroup", "is_forum": true}, "from": {"id": 1, "first_name": "Ann"}, "new_chat_members": [{"id": 2, "is_bot": true, "first_name": "Bot"}]})
+      created = %({"message_id": 11, "message_thread_id": 5, "is_topic_message": true, "chat": {"id": -1001, "type": "supergroup", "is_forum": true}, "from": {"id": 1, "first_name": "Ann"}, "forum_topic_created": {"name": "memo", "icon_color": 1}})
+      channel.test_service_message?(JSON.parse(joined)).should be_true
+      channel.test_service_message?(JSON.parse(created)).should be_true
+      channel.test_service_message?(JSON.parse(GENERAL_MESSAGE)).should be_false
+      channel.test_service_message?(JSON.parse(TOPIC_MESSAGE)).should be_false
     end
 
     it "owns the General topic of a forum as topic 1" do

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -304,6 +304,12 @@ module Autobot::Channels
 
     MEDIA_LOG_LABEL     = "[media]"
     EMPTY_MESSAGE_LABEL = "[empty message]"
+    SERVICE_FIELDS      = %w[new_chat_members left_chat_member new_chat_title new_chat_photo delete_chat_photo
+      group_chat_created supergroup_chat_created channel_chat_created message_auto_delete_timer_changed
+      migrate_to_chat_id migrate_from_chat_id pinned_message forum_topic_created forum_topic_edited
+      forum_topic_closed forum_topic_reopened general_forum_topic_hidden general_forum_topic_unhidden
+      video_chat_scheduled video_chat_started video_chat_ended video_chat_participants_invited
+      proximity_alert_triggered write_access_allowed boost_added chat_background_set]
 
     @offset : Int64 = 0_i64
     @bot_username : String = ""
@@ -567,6 +573,11 @@ module Autobot::Channels
       sender = extract_sender(msg)
       return unless sender
 
+      if service_message?(msg)
+        Log.debug { "Ignored service message in #{sender[:chat_id]}" }
+        return
+      end
+
       if text = msg["text"]?.try(&.as_s)
         if text.starts_with?('/')
           handle_command(text, sender[:chat_id], sender[:sender_id], sender[:first_name])
@@ -643,6 +654,10 @@ module Autobot::Channels
       return nil unless reply_msg
 
       reply_msg["text"]?.try(&.as_s) || reply_msg["caption"]?.try(&.as_s)
+    end
+
+    private def service_message?(msg : JSON::Any) : Bool
+      SERVICE_FIELDS.any? { |field| !msg[field]?.nil? }
     end
 
     private def typed_text(msg : JSON::Any) : String?


### PR DESCRIPTION
## Overview

- [x] service messages (a member joining, a pinned message, a topic created or edited, video chat events) are skipped instead of being answered as empty messages, which a bot owning a topic would otherwise do
- [x] docs mention it under forum topics