### PR TITLE
fix(sandbox): bind the system config a toolchain needs

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -42,14 +42,42 @@ Sandbox.exec("ls -1a #{shell_escape(path)} 2>&1", workspace, timeout: 10)
 ```bash
 bwrap \
   --ro-bind /usr /usr \
+  --ro-bind /lib /lib \
   --ro-bind /bin /bin \
+  --ro-bind /sbin /sbin \
   --bind /workspace /workspace \
-  --unshare-all \
   --proc /proc \
   --dev /dev \
+  --unshare-all \
+  --share-net \
+  --die-with-parent \
   --chdir /workspace \
+  --ro-bind /etc/alternatives /etc/alternatives \
+  --ro-bind /etc/ld.so.cache /etc/ld.so.cache \
+  --ro-bind /etc/resolv.conf /etc/resolv.conf \
+  --ro-bind /etc/ssl /etc/ssl \
+  --tmpfs /tmp \
   -- sh -c "cat file.txt"
 ```
+
+The `/etc` lines are a sample: every path in `Sandbox::SYSTEM_CONFIG_PATHS` that exists on the host is bound read-only the same way, and so is `/lib64` when present.
+
+**What the sandbox can see**
+
+| Path | Access | Why |
+|------|--------|-----|
+| `/usr`, `/lib`, `/lib64`, `/bin`, `/sbin` | read-only | host-installed tools and libraries |
+| `/etc/alternatives` | read-only | Debian-based hosts resolve `python3`, `awk`, `which`, `cc` and libraries such as `libblas.so.3` through it |
+| `/etc/ld.so.cache`, `/etc/ld.so.conf`, `/etc/ld.so.conf.d` | read-only | dynamic loader library lookup |
+| `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf` | read-only | DNS resolution |
+| `/etc/ssl`, `/etc/ca-certificates` | read-only | TLS trust store for `curl`, Python and friends |
+| `/etc/localtime` | read-only | local time zone |
+| `/etc/passwd`, `/etc/group` | read-only | user and group names (`whoami`, `ls -l`) |
+| `/etc/matplotlibrc` | read-only | Debian's `python3-matplotlib` keeps its only config file here |
+| workspace | read-write | the bot's files |
+| `/proc`, `/dev`, `/tmp` | private | fresh per command, `/tmp` is an empty tmpfs |
+
+Each `/etc` entry is bound only when it exists on the host. Nothing else from the host is mounted: the rest of `/etc`, home directories, `/var`, `/opt` and `/srv` are not visible. The sandbox root is an empty tmpfs, so a command can create missing paths such as `$HOME`, but they vanish when it exits.
 
 ### Execution (macOS/Universal - Docker)
 
@@ -181,7 +209,7 @@ docker build -t autobot-sandbox -f Dockerfile.sandbox .
 
 ### What Sandboxing Prevents
 
-- Reading system files (`/etc/passwd`, `/etc/shadow`)
+- Reading host files outside the read-only system paths (`/etc/shadow`, the rest of `/etc`)
 - Reading home directory (`~/.ssh/`, `~/.aws/credentials`)
 - Writing outside workspace
 - Accessing secrets in parent directories
@@ -190,7 +218,7 @@ docker build -t autobot-sandbox -f Dockerfile.sandbox .
 
 ### How It Works
 
-All filesystem and exec operations go through `SandboxExecutor`, which routes them to `Sandbox.exec`. Each operation spawns a sandboxed process (bubblewrap or Docker) that **cannot access files outside the workspace** — enforced by the OS kernel, not application code.
+All filesystem and exec operations go through `SandboxExecutor`, which routes them to `Sandbox.exec`. Each operation spawns a sandboxed process (bubblewrap or Docker) that **cannot write outside the workspace and sees the host only through the read-only system paths listed above** — enforced by the OS kernel, not application code.
 
 **Shell escaping** (single-quote escaping, base64 encoding for file content) prevents command injection within sandboxed commands.
 

--- a/spec/autobot/tools/sandbox_spec.cr
+++ b/spec/autobot/tools/sandbox_spec.cr
@@ -130,6 +130,36 @@ describe Autobot::Tools::Sandbox do
     end
   end
 
+  describe ".system_config_binds" do
+    it "binds existing paths read-only and skips missing ones" do
+      tmp = TestHelper.tmp_dir
+      existing = tmp.to_s
+      missing = (tmp / "missing").to_s
+
+      args = Autobot::Tools::Sandbox.system_config_binds([existing, missing])
+
+      args.should eq(["--ro-bind", existing, existing])
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
+    it "binds /etc/alternatives on hosts that have it" do
+      pending! "host has no /etc/alternatives" unless File.exists?("/etc/alternatives")
+
+      binds = Autobot::Tools::Sandbox.system_config_binds.each_slice(3).to_a
+
+      binds.should contain(["--ro-bind", "/etc/alternatives", "/etc/alternatives"])
+    end
+
+    it "binds only paths that exist on the host" do
+      Autobot::Tools::Sandbox.system_config_binds.each_slice(3) do |(flag, source, target)|
+        flag.should eq("--ro-bind")
+        target.should eq(source)
+        File.exists?(source).should be_true
+      end
+    end
+  end
+
   describe "constants" do
     it "has sandbox dockerfile name" do
       Autobot::Tools::Sandbox::SANDBOX_DOCKERFILE.should eq("Dockerfile.sandbox")

--- a/src/autobot/tools/sandbox.cr
+++ b/src/autobot/tools/sandbox.cr
@@ -129,6 +129,23 @@ module Autobot
         end
       end
 
+      # /usr/bin/python3 and friends are symlinks into /etc/alternatives on Debian-based hosts
+      SYSTEM_CONFIG_PATHS = [
+        "/etc/alternatives",
+        "/etc/ld.so.cache",
+        "/etc/ld.so.conf",
+        "/etc/ld.so.conf.d",
+        "/etc/resolv.conf",
+        "/etc/hosts",
+        "/etc/nsswitch.conf",
+        "/etc/ssl",
+        "/etc/ca-certificates",
+        "/etc/localtime",
+        "/etc/passwd",
+        "/etc/group",
+        "/etc/matplotlibrc", # Debian's python3-matplotlib keeps its only matplotlibrc here
+      ]
+
       private def self.run_in_bubblewrap(
         cmd_args : Array(String),
         workspace : Path,
@@ -151,11 +168,16 @@ module Autobot
           "--chdir", workspace_real,
         ]
         args.push("--ro-bind", "/lib64", "/lib64") if Dir.exists?("/lib64")
+        args.concat(system_config_binds)
         args.push("--tmpfs", "/tmp")
         args.push("--")
         args.concat(cmd_args)
 
         capture_command("bwrap", args, timeout, max_output_size)
+      end
+
+      def self.system_config_binds(paths : Array(String) = SYSTEM_CONFIG_PATHS) : Array(String)
+        paths.select { |path| File.exists?(path) }.flat_map { |path| ["--ro-bind", path, path] }
       end
 
       private def self.run_in_docker(


### PR DESCRIPTION
## Overview

- [x] the bubblewrap sandbox binds `/etc/alternatives`, the dynamic loader cache and config, DNS and TLS config, `/etc/localtime`, `/etc/passwd`, `/etc/group` and `/etc/matplotlibrc` read-only when they exist on the host, so `python3` and other alternatives-managed tools resolve on Debian-based hosts, name resolution and certificate verification work, and Debian's `python3-matplotlib` imports
- [x] docs list what the sandbox can see
- [x] spec covers the bind helper: existing paths are bound read-only, missing ones are skipped

## Findings

Reproduced by hand on an Ubuntu 22.04 host (aarch64, bubblewrap 0.6.1) with the exact argument list the code builds. Inside the sandbox `/etc` did not exist at all, so:

- `/usr/bin/python3 -> /etc/alternatives/python3` dangled: `sh: 1: python3: not found` (exit 127). `which`, `awk`, `cc` and about 40 other alternatives-managed tools were missing too, and numpy failed with `ImportError: libblas.so.3: cannot open shared object file` because that library is an alternatives symlink as well
- DNS: `socket.gaierror: [Errno -3] Temporary failure in name resolution`, `curl: (6) Could not resolve host`
- TLS (with only the DNS files bound): `[SSL: CERTIFICATE_VERIFY_FAILED] self-signed certificate in certificate chain`, `curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt`
- `whoami: cannot find name for user ID ...`, and `date` reported UTC instead of the host time zone
- matplotlib: `RuntimeError: Could not find matplotlibrc file; your Matplotlib install is broken`, because Debian's package keeps its only `matplotlibrc` at `/etc/matplotlibrc`

With the new binds `python3`, DNS, HTTPS, `whoami`, the local time zone and a matplotlib chart all work, and `/etc` inside the sandbox contains only the bound entries. `HOME` needs no change: the sandbox root is a tmpfs owned by the sandbox uid, so tools can create their config directories there (matplotlib's font cache costs about a second per run and falls back to `/tmp` with a warning when `HOME` is unwritable).

Existence checks stay in Crystal instead of `--ro-bind-try` so the argument list is testable and independent of the bubblewrap version.
