### PR TITLE
fix(telegram): route group commands to the bot they address

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -147,6 +147,7 @@ channels:
 - The chat ID becomes `<group>:<topic>`, for example `-1001234567890:57`, so each topic has its own session, its own `/reset` and its own cron delivery target. Use that form as the `to` of a cron job or a message tool call to reach a topic.
 - The bot must see the topic's messages: turn off privacy mode for it in BotFather (`/setprivacy`), or make it a group admin, then remove and re-add it to the group.
 - Service messages, such as a member joining, a pinned message or a topic being created, are ignored, so owning a topic never makes the bot comment on them.
+- A command in a group is handled by the bot it names, as in `/help@mybot`, or, without a name, by the bot that owns the topic or is mentioned; other bots stay silent. An unknown command gets a one-line reply pointing to `/help`.
 
 ## Troubleshooting
 

--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -40,6 +40,16 @@ class TelegramChannelTest < Autobot::Channels::TelegramChannel
     extract_sender(msg)
   end
 
+  def test_bot_username=(name : String)
+    @bot_username = name
+  end
+
+  def test_command_for_me?(text : String, msg : JSON::Any) : Bool
+    sender = extract_sender(msg)
+    raise "no sender" unless sender
+    command_for_me?(text, msg, sender)
+  end
+
   def test_service_message?(msg : JSON::Any) : Bool
     service_message?(msg)
   end
@@ -161,6 +171,7 @@ end
 
 private TOPIC_MESSAGE   = %({"message_id": 9, "message_thread_id": 57, "is_topic_message": true, "chat": {"id": -1001, "type": "supergroup"}, "from": {"id": 1, "first_name": "Ann"}, "text": "hi"})
 private GENERAL_REPLY   = %({"message_id": 9, "message_thread_id": 3, "chat": {"id": -1001, "type": "supergroup"}, "from": {"id": 1, "first_name": "Ann"}, "text": "hi"})
+private PRIVATE_MESSAGE = %({"message_id": 1, "chat": {"id": 5, "type": "private"}, "from": {"id": 1, "first_name": "Ann"}, "text": "/help"})
 private GENERAL_MESSAGE = %({"message_id": 9, "chat": {"id": -1001, "type": "supergroup", "is_forum": true}, "from": {"id": 1, "first_name": "Ann"}, "text": "hi"})
 
 describe Autobot::Channels::TelegramChannel do
@@ -182,6 +193,17 @@ describe Autobot::Channels::TelegramChannel do
       channel.test_service_message?(JSON.parse(created)).should be_true
       channel.test_service_message?(JSON.parse(GENERAL_MESSAGE)).should be_false
       channel.test_service_message?(JSON.parse(TOPIC_MESSAGE)).should be_false
+    end
+
+    it "handles a group command only when it names this bot or lands in an owned topic" do
+      channel = TelegramChannelTest.new(bus: Autobot::Bus::MessageBus.new, token: "t", topics: [57_i64])
+      channel.test_bot_username = "mybot"
+      channel.test_command_for_me?("/help@mybot", JSON.parse(GENERAL_REPLY)).should be_true
+      channel.test_command_for_me?("/help@MyBot", JSON.parse(GENERAL_REPLY)).should be_true
+      channel.test_command_for_me?("/help@otherbot", JSON.parse(TOPIC_MESSAGE)).should be_false
+      channel.test_command_for_me?("/help", JSON.parse(TOPIC_MESSAGE)).should be_true
+      channel.test_command_for_me?("/help", JSON.parse(GENERAL_REPLY)).should be_false
+      channel.test_command_for_me?("/help", JSON.parse(PRIVATE_MESSAGE)).should be_true
     end
 
     it "owns the General topic of a forum as topic 1" do

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -578,12 +578,7 @@ module Autobot::Channels
         return
       end
 
-      if text = msg["text"]?.try(&.as_s)
-        if text.starts_with?('/')
-          handle_command(text, sender[:chat_id], sender[:sender_id], sender[:first_name])
-          return
-        end
-      end
+      return if handle_command_message(msg, sender)
 
       display_name = sender[:username] ? "@#{sender[:username]}" : sender[:first_name]
 
@@ -838,7 +833,10 @@ module Autobot::Channels
       if entry = @custom_commands.scripts[command]?
         start_typing(chat_id)
         execute_script(entry.value, args, chat_id)
+        return
       end
+
+      send_reply(chat_id, "Unknown command /#{command}. Type /help to see the available commands.")
     end
 
     SCRIPT_OUTPUT_LIMIT = 4000
@@ -1096,6 +1094,21 @@ module Autobot::Channels
         "text"       => text,
         "parse_mode" => "HTML",
       })
+    end
+
+    private def handle_command_message(msg : JSON::Any, sender : Sender) : Bool
+      text = msg["text"]?.try(&.as_s)
+      return false unless text && text.starts_with?('/')
+      handle_command(text, sender[:chat_id], sender[:sender_id], sender[:first_name]) if command_for_me?(text, msg, sender)
+      true
+    end
+
+    private def command_for_me?(text : String, msg : JSON::Any, sender : Sender) : Bool
+      target = text.split(' ', 2)[0].split('@', 2)[1]?
+      if target && !target.empty?
+        return target.compare(@bot_username, case_insensitive: true) == 0
+      end
+      addressed?(msg, sender)
     end
 
     private def addressed?(msg : JSON::Any, sender : Sender) : Bool


### PR DESCRIPTION
## Overview

- [x] a command in a group is handled only by the bot named in its `@suffix`, or, without a suffix, by the bot that owns the topic or is mentioned; before, every bot that could see `/help@one_bot` answered it
- [x] an unknown command gets a one-line reply pointing to `/help` instead of silence
- [x] docs describe both under forum topics