### PR TITLE
feat(tools): keep the skills directory readable under filesystem roots

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,7 +157,7 @@ When sandboxed, all shell commands run inside the sandbox (bubblewrap or Docker)
 
 ### Filesystem Roots
 
-`tools.filesystem.roots` limits `read_file`, `write_file`, `edit_file` and `list_dir` to the listed workspace subdirectories. Paths resolve relative to the workspace and `..` cannot escape a root. Commands run by `exec` are not affected; they stay bound to the workspace by the sandbox.
+`tools.filesystem.roots` limits `read_file`, `write_file`, `edit_file` and `list_dir` to the listed workspace subdirectories. Paths resolve relative to the workspace and `..` cannot escape a root. The workspace `skills/` directory stays readable whether or not it is listed: a skill's references and scripts are prompt material the model reads on demand. Writes there are refused unless it is a root. Commands run by `exec` are not affected; they stay bound to the workspace by the sandbox.
 
 ### Safety Guard Overrides
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -293,7 +293,7 @@ tools:
     roots: [notes, inbox]
 ```
 
-`tools.enabled` is an allowlist applied at registration, so a tool that is not listed does not exist for the model, whether it is built in, a skill script, a plugin or an MCP tool. `tools.filesystem.roots` keeps the file tools inside the listed workspace subdirectories. With both in place, the worst a planted instruction inside an attachment can do is write a bad note. `autobot doctor` prints the effective tool list and reminds you to set the allowlist when it is missing.
+`tools.enabled` is an allowlist applied at registration, so a tool that is not listed does not exist for the model, whether it is built in, a skill script, a plugin or an MCP tool. `tools.filesystem.roots` keeps the file tools inside the listed workspace subdirectories, with `skills/` readable on top so a skill's references can be read on demand. With both in place, the worst a planted instruction inside an attachment can do is write a bad note. `autobot doctor` prints the effective tool list and reminds you to set the allowlist when it is missing.
 
 ---
 

--- a/spec/autobot/agent/skills_spec.cr
+++ b/spec/autobot/agent/skills_spec.cr
@@ -133,6 +133,7 @@ describe Autobot::Agent::SkillsLoader do
     summary.should contain("<skills>")
     summary.should contain("<name>test</name>")
     summary.should contain("</skills>")
+    loader.build_skills_summary(exclude: ["test"]).should eq("")
   ensure
     FileUtils.rm_rf(tmp) if tmp
   end

--- a/spec/autobot/tools/filesystem_roots_spec.cr
+++ b/spec/autobot/tools/filesystem_roots_spec.cr
@@ -5,7 +5,9 @@ private def with_roots(&)
   Dir.mkdir_p(workspace / "notes")
   Dir.mkdir_p(workspace / "inbox")
   Dir.mkdir_p(workspace / "memory")
+  Dir.mkdir_p(workspace / "skills" / "memo" / "references")
   File.write(workspace / "notes" / "a.md", "note")
+  File.write(workspace / "skills" / "memo" / "references" / "script.md", "commands")
   File.write(workspace / "memory" / "MEMORY.md", "secret")
   roots = Autobot::Tools.resolve_roots(["notes", "inbox"], workspace)
   yield Autobot::Tools::SandboxExecutor.new(workspace, false, roots), workspace
@@ -40,6 +42,17 @@ describe Autobot::Tools::SandboxExecutor do
         executor.write_file((workspace / "SOUL.md").to_s, "x").success?.should be_false
         executor.list_dir(workspace.to_s).success?.should be_false
         executor.read_file_base64("/etc/hosts").success?.should be_false
+      end
+    end
+
+    it "keeps the skills directory readable but not writable" do
+      with_roots do |executor, workspace|
+        reference = (workspace / "skills" / "memo" / "references" / "script.md").to_s
+        executor.read_file(reference).content.should eq("commands")
+        executor.list_dir((workspace / "skills" / "memo").to_s).content.should contain("references")
+        executor.read_file_base64(reference).success?.should be_true
+        executor.write_file("skills/memo/SKILL.md", "x").content.should contain("outside the allowed directories")
+        executor.read_file("skills/../memory/MEMORY.md").success?.should be_false
       end
     end
 

--- a/src/autobot/agent/context.cr
+++ b/src/autobot/agent/context.cr
@@ -161,12 +161,12 @@ module Autobot::Agent
 
         unless auto_skills.empty?
           auto_content = @skills.load_skills_for_context(auto_skills)
-          parts << "# Active Skills\n\n#{auto_content}" unless auto_content.empty?
+          parts << "# Active Skills\n\nThese skills are loaded in full. A file one of them points to, such as a reference under its folder in skills/, can be read with the read_file tool.\n\n#{auto_content}" unless auto_content.empty?
         end
 
         # Available skills: show summary for progressive loading (skip for background)
         unless background
-          skills_summary = @skills.build_skills_summary
+          skills_summary = @skills.build_skills_summary(exclude: auto_skills)
           unless skills_summary.empty?
             parts << <<-SKILLS
             # Skills

--- a/src/autobot/agent/skills.cr
+++ b/src/autobot/agent/skills.cr
@@ -107,9 +107,9 @@ module Autobot
         parts.join("\n\n---\n\n")
       end
 
-      # Build an XML summary of all skills for progressive loading.
-      def build_skills_summary : String
-        all_skills = list_skills(filter_unavailable: false)
+      # Build an XML summary of the skills not already in context, for progressive loading.
+      def build_skills_summary(exclude : Array(String) = [] of String) : String
+        all_skills = list_skills(filter_unavailable: false).reject { |skill_info| exclude.includes?(skill_info.name) }
         return "" if all_skills.empty?
 
         lines = ["<skills>"]

--- a/src/autobot/tools/sandbox_executor.cr
+++ b/src/autobot/tools/sandbox_executor.cr
@@ -13,6 +13,7 @@ module Autobot
     #   result = executor.exec("ls -la")
     class SandboxExecutor
       MAX_FILE_SIZE = 1_048_576
+      SKILLS_DIR    = "skills"
 
       getter? sandboxed : Bool = true
       getter roots : Array(Path)
@@ -21,7 +22,7 @@ module Autobot
       end
 
       def read_file(path : String) : ToolResult
-        outside_roots(path).try { |error| return error }
+        outside_roots(path, reading: true).try { |error| return error }
 
         if @sandboxed && (workspace = @workspace)
           read_file_via_sandbox_exec(path, workspace)
@@ -35,7 +36,7 @@ module Autobot
       # Read a file and return base64-encoded contents.
       # Safe for binary files (images, GIFs, documents).
       def read_file_base64(path : String) : ToolResult
-        outside_roots(path).try { |error| return error }
+        outside_roots(path, reading: true).try { |error| return error }
 
         if @sandboxed && (workspace = @workspace)
           success, output = Sandbox.read_file_base64(path, workspace)
@@ -60,7 +61,7 @@ module Autobot
       end
 
       def list_dir(path : String) : ToolResult
-        outside_roots(path).try { |error| return error }
+        outside_roots(path, reading: true).try { |error| return error }
 
         if @sandboxed && (workspace = @workspace)
           list_dir_via_sandbox_exec(path, workspace)
@@ -92,15 +93,20 @@ module Autobot
       end
 
       # Sandbox.exec-based execution
-      private def outside_roots(path : String) : ToolResult?
+      private def outside_roots(path : String, reading : Bool = false) : ToolResult?
         return nil if @roots.empty?
 
         base = @workspace || Path[Dir.current]
         resolved = Path[path].expand(base: base, home: true)
-        return nil if @roots.any? { |root| resolved == root || resolved.to_s.starts_with?("#{root}/") }
+        return nil if @roots.any? { |root| inside?(resolved, root) }
+        return nil if reading && inside?(resolved, base / SKILLS_DIR)
 
         names = @roots.map(&.relative_to(base).to_s)
         ToolResult.error("Path is outside the allowed directories (#{names.join(", ")}): #{path}")
+      end
+
+      private def inside?(resolved : Path, root : Path) : Bool
+        resolved == root || resolved.to_s.starts_with?("#{root}/")
       end
 
       private def read_file_via_sandbox_exec(path : String, workspace : Path) : ToolResult


### PR DESCRIPTION
## Overview

- [x] read_file, read_file_base64 and list_dir reach the workspace skills/ directory even when tools.filesystem.roots leaves it out; writes there stay refused
- [x] the skills summary in the system prompt skips skills already loaded under Active Skills, and that section says a file a skill points to can be read with read_file
- [x] specs for the readable skills directory and the summary exclusion; docs for roots in configuration.md and security.md

A skill in the Agent Skills shape keeps its command reference under references/ and expects the model to read it on demand. With roots set to the data directories, that read failed and the model guessed the commands.