### PR TITLE
fix(cron): deliver exec output without a code block

### DIFF
--- a/spec/autobot/cron/formatter_spec.cr
+++ b/spec/autobot/cron/formatter_spec.cr
@@ -121,6 +121,14 @@ describe Autobot::Cron::Formatter do
     end
   end
 
+  describe ".format_exec_output" do
+    it "keeps the output as the command wrote it" do
+      job = Autobot::Cron::CronJob.new(id: "j1", name: "Tekst dnia")
+      result = Autobot::Cron::Formatter.format_exec_output(job, "**bold** line")
+      result.should eq("⚡ **Tekst dnia**\n\n**bold** line")
+    end
+  end
+
   describe ".format_duration" do
     it "formats seconds" do
       Autobot::Cron::Formatter.format_duration(30_000_i64).should eq("30s")

--- a/src/autobot/cron/formatter.cr
+++ b/src/autobot/cron/formatter.cr
@@ -129,9 +129,9 @@ module Autobot
         end
       end
 
-      # Markdown-formatted exec job output notification.
+      # Exec job output notification; the command's stdout keeps the formatting it was written with.
       def self.format_exec_output(job : CronJob, output : String) : String
-        "⚡ **#{job.name}**\n\n```\n#{output}\n```"
+        "⚡ **#{job.name}**\n\n#{output}"
       end
 
       # HTML-formatted job line for Telegram cron list.


### PR DESCRIPTION
## Overview

- [x] exec cron output is delivered as written, no forced markdown code fence
- [x] a command that prints bold or links now renders instead of showing escaped monospace
- [x] spec for `format_exec_output`