### PR TITLE
fix(media): make long audio memos usable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,8 +41,11 @@ Voice notes are transcribed with the Whisper API. By default the key is reused f
 transcription:
   enabled: true              # false: voice notes are never transcribed
   provider: groq             # openai or groq; default picks groq, then openai
+  model: whisper-large-v3    # optional; overrides the provider default
   api_key: "${WHISPER_KEY}"  # own key, separate from the chat provider
 ```
+
+`model` is passed to the provider as given. Groq serves `whisper-large-v3-turbo` (the default, fastest and cheapest) and `whisper-large-v3`, which is slower but transcribes long or noisy recordings more accurately.
 
 With `enabled: false`, or when no key is available, a voice note is saved to the inbox without a transcript and the bot replies that it could not hear it, without a model turn. `autobot doctor` prints the provider in use, whether it runs on its own key, and warns when a pinned provider has no key.
 
@@ -157,7 +160,7 @@ When sandboxed, all shell commands run inside the sandbox (bubblewrap or Docker)
 
 ### Filesystem Roots
 
-`tools.filesystem.roots` limits `read_file`, `write_file`, `edit_file` and `list_dir` to the listed workspace subdirectories. Paths resolve relative to the workspace and `..` cannot escape a root. The workspace `skills/` directory stays readable whether or not it is listed: a skill's references and scripts are prompt material the model reads on demand. Writes there are refused unless it is a root. Commands run by `exec` are not affected; they stay bound to the workspace by the sandbox.
+`tools.filesystem.roots` limits `read_file`, `write_file`, `edit_file` and `list_dir` to the listed workspace subdirectories. Paths resolve relative to the workspace and `..` cannot escape a root. The workspace `skills/` directory stays readable whether or not it is listed: a skill's references and scripts are prompt material the model reads on demand. Writes there are refused unless it is a root. The media inbox is added to the roots automatically, because the engine hands the agent inbox paths for stored files and long transcripts. Commands run by `exec` are not affected; they stay bound to the workspace by the sandbox.
 
 ### Safety Guard Overrides
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -74,7 +74,7 @@ in front of it.
 
 The rendered text, blocks included, is what the session history stores, so a
 later turn can still answer questions about an earlier attachment. A transcript
-longer than 4,000 characters is cut in the block with a pointer to the full
+longer than 24,000 characters is cut in the block with a pointer to the full
 transcript file in the inbox, which the agent can read on demand.
 
 ## Vision
@@ -275,12 +275,14 @@ Voice notes and audio files received via Telegram are transcribed using the Whis
 ```
 Voice note from the sender -> Download -> Transcriber -> "[voice transcription]: ..." in message content -> LLM
 Audio file or forwarded note -> Download -> Transcriber -> transcript on the attachment            -> LLM
+Document with an audio type -> Download -> Transcriber -> transcript on the attachment            -> LLM
 ```
 
 1. **Channel** receives a voice note or audio file and downloads the file bytes
 2. **Transcriber** sends the audio to the Whisper API (OpenAI or Groq) and receives text
 3. For a voice note the sender recorded, with no typed text, the transcript becomes the message content as `[voice transcription]: {text}`
 4. For an audio file, a forwarded voice note, or a voice note with typed text, the transcript is stored on the attachment and the message content only carries a label such as `[audio: title]`
+5. A document is transcribed too when its type is audio, which is how a recording shared as a file rather than as a track arrives
 
 ### Configuration
 

--- a/spec/autobot/agent/attachments_spec.cr
+++ b/spec/autobot/agent/attachments_spec.cr
@@ -36,7 +36,7 @@ describe Autobot::Agent::Attachments do
   end
 
   it "truncates a long transcript and points at the transcript file" do
-    long = "word " * 1000
+    long = "word " * (Autobot::Agent::Attachments::MAX_INLINE_TRANSCRIPT // 5 + 1)
     rendered = render(type: "audio", transcript: long, transcript_path: "/srv/bot/workspace/inbox/memo.txt")
 
     rendered.should contain(long[0, Autobot::Agent::Attachments::MAX_INLINE_TRANSCRIPT])

--- a/spec/autobot/channels/telegram_media_spec.cr
+++ b/spec/autobot/channels/telegram_media_spec.cr
@@ -170,6 +170,31 @@ describe Autobot::Channels::TelegramMedia do
       attachments.first.mime_type.should eq("application/pdf")
     end
 
+    it "transcribes a document that carries audio" do
+      transcriber = FakeTranscriber.new
+      media = build_media(transcriber)
+      msg = message(%({"document": {"file_id": "d3", "file_name": "meeting.m4a", "mime_type": "audio/x-m4a"}}))
+
+      parts, attachments = media.extract(msg, typed_text: false)
+
+      parts.should eq(["[document: meeting.m4a]"])
+      attachment = attachments.first
+      attachment.transcript.should eq("spoken words")
+      attachment.transcribed?.should be_true
+      transcriber.calls.should eq(["audio.m4a"])
+    end
+
+    it "leaves a document alone when it is not audio" do
+      transcriber = FakeTranscriber.new
+      media = build_media(transcriber)
+      msg = message(%({"document": {"file_id": "d4", "file_name": "report.pdf", "mime_type": "application/pdf"}}))
+
+      _, attachments = media.extract(msg, typed_text: false)
+
+      attachments.first.transcript.should be_nil
+      transcriber.calls.should be_empty
+    end
+
     it "keeps document bytes for vision when mime type is an image" do
       media = build_media(bytes: "png-bytes".to_slice)
       msg = message(%({"document": {"file_id": "d2", "file_name": "photo.png", "mime_type": "image/png"}}))

--- a/spec/autobot/config/schema_spec.cr
+++ b/spec/autobot/config/schema_spec.cr
@@ -215,10 +215,42 @@ describe Autobot::Config::Config do
       Autobot::Config::Config.from_yaml("transcription:\n  provider: whisperx\n").transcription.provider_known?.should be_false
     end
 
+    it "carries a transcription model through to the source" do
+      config = Autobot::Config::Config.from_yaml("transcription:\n  provider: groq\n  model: whisper-large-v3\n  api_key: gsk\n")
+      source = config.transcription_source.should_not be_nil
+      source.provider.should eq("groq")
+      source.model.should eq("whisper-large-v3")
+    end
+
+    it "leaves the transcription model unset by default" do
+      Autobot::Config::Config.from_yaml("transcription:\n  api_key: gsk\n").transcription_source.try(&.model).should be_nil
+    end
+
     it "defaults to all tools and the whole workspace" do
       config = Autobot::Config::Config.from_yaml("tools:\n  sandbox: none\n")
       config.tools.try(&.enabled).should eq([] of String)
       config.tools.try(&.filesystem).should be_nil
+    end
+  end
+
+  describe "#filesystem_roots" do
+    it "adds the inbox so engine-supplied paths stay readable" do
+      config = Autobot::Config::Config.from_yaml("tools:\n  filesystem:\n    roots: [skills, vendor]\n")
+      config.filesystem_roots.should eq(["skills", "vendor", "inbox"])
+    end
+
+    it "does not repeat an inbox that is already listed" do
+      config = Autobot::Config::Config.from_yaml("tools:\n  filesystem:\n    roots: [inbox]\n")
+      config.filesystem_roots.should eq(["inbox"])
+    end
+
+    it "honours a renamed inbox" do
+      config = Autobot::Config::Config.from_yaml("media:\n  inbox: incoming\ntools:\n  filesystem:\n    roots: [notes]\n")
+      config.filesystem_roots.should eq(["notes", "incoming"])
+    end
+
+    it "stays empty when no roots are configured, leaving the whole workspace open" do
+      Autobot::Config::Config.from_yaml("{}").filesystem_roots.should be_empty
     end
   end
 

--- a/spec/autobot/media/types_spec.cr
+++ b/spec/autobot/media/types_spec.cr
@@ -12,6 +12,27 @@ describe Autobot::Media::Types do
     end
   end
 
+  describe ".audio?" do
+    it "recognises audio mime types, parameters and case included" do
+      Autobot::Media::Types.audio?("audio/mp4").should be_true
+      Autobot::Media::Types.audio?("Audio/OGG; codecs=opus").should be_true
+      Autobot::Media::Types.audio?("audio/x-m4a").should be_true
+    end
+
+    it "rejects everything else" do
+      Autobot::Media::Types.audio?("application/pdf").should be_false
+      Autobot::Media::Types.audio?(nil).should be_false
+    end
+  end
+
+  describe ".image?" do
+    it "recognises image mime types and rejects the rest" do
+      Autobot::Media::Types.image?("image/png").should be_true
+      Autobot::Media::Types.image?("audio/mp4").should be_false
+      Autobot::Media::Types.image?(nil).should be_false
+    end
+  end
+
   describe ".extension_for" do
     it "ignores mime parameters and case" do
       Autobot::Media::Types.extension_for("Audio/OGG; codecs=opus", ".bin").should eq(".ogg")

--- a/src/autobot/agent/attachments.cr
+++ b/src/autobot/agent/attachments.cr
@@ -4,7 +4,7 @@ require "../bus/events"
 module Autobot
   module Agent
     module Attachments
-      MAX_INLINE_TRANSCRIPT = 4000
+      MAX_INLINE_TRANSCRIPT = 24_000
 
       def self.render(attachment : Bus::MediaAttachment, workspace_root : Path) : String
         "<attachment#{attributes(attachment, workspace_root)}>\n#{body(attachment, workspace_root)}\n</attachment>"

--- a/src/autobot/channels/telegram_media.cr
+++ b/src/autobot/channels/telegram_media.cr
@@ -70,12 +70,13 @@ module Autobot::Channels
       document = msg["document"]?
       return nil unless document
 
-      format = format_of(document, Bus::MediaAttachment::TYPE_DOCUMENT, Media::Types::DEFAULT[1])
+      extension, mime = format = format_of(document, Bus::MediaAttachment::TYPE_DOCUMENT, Media::Types::DEFAULT[1])
       bytes = fetch(document)
-      data = format[1].starts_with?("image/") && bytes ? Base64.strict_encode(bytes) : nil
+      data = Media::Types.image?(mime) && bytes ? Base64.strict_encode(bytes) : nil
 
       build(Bus::MediaAttachment::TYPE_DOCUMENT, document, origin, format, bytes,
         data: data,
+        transcript: Media::Types.audio?(mime) ? transcribe(bytes, extension) : nil,
         name: string_of(document, "file_name"))
     end
 

--- a/src/autobot/cli/doctor.cr
+++ b/src/autobot/cli/doctor.cr
@@ -232,7 +232,7 @@ module Autobot
       end
 
       def self.check_filesystem_roots(config : Config::Config, warnings : Int32) : Int32
-        roots = config.tools.try(&.filesystem.try(&.roots)) || [] of String
+        roots = config.filesystem_roots
         return warnings if roots.empty?
 
         workspace = config.workspace_path

--- a/src/autobot/cli/gateway.cr
+++ b/src/autobot/cli/gateway.cr
@@ -164,7 +164,7 @@ module Autobot
           sandbox_config: sandbox_config,
           rate_limiter: rate_limiter,
           enabled_tools: config.tools.try(&.enabled) || [] of String,
-          filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
+          filesystem_roots: config.filesystem_roots,
           web_allowed_domains: config.tools.try(&.web.try(&.allowed_domains)) || [] of String,
           max_tokens: defaults.try(&.max_tokens) || agent_defaults.max_tokens,
           temperature: defaults.try(&.temperature) || agent_defaults.temperature,

--- a/src/autobot/cli/setup_helper.cr
+++ b/src/autobot/cli/setup_helper.cr
@@ -116,7 +116,7 @@ module Autobot
           ],
           rate_limiter: rate_limiter,
           enabled_tools: config.tools.try(&.enabled) || [] of String,
-          filesystem_roots: config.tools.try(&.filesystem.try(&.roots)) || [] of String,
+          filesystem_roots: config.filesystem_roots,
           web_allowed_domains: config.tools.try(&.web.try(&.allowed_domains)) || [] of String,
         )
 

--- a/src/autobot/config/schema.cr
+++ b/src/autobot/config/schema.cr
@@ -321,11 +321,12 @@ module Autobot::Config
     PROVIDERS        = %w[groq openai]
     DEFAULT_PROVIDER = "openai"
 
-    record Source, provider : String, api_key : String, own_key : Bool
+    record Source, provider : String, api_key : String, own_key : Bool, model : String? = nil
 
     property? enabled : Bool = true
     property provider : String? = nil
     property api_key : String? = nil
+    property model : String? = nil
 
     def initialize
     end
@@ -441,17 +442,25 @@ module Autobot::Config
       Path[media.inbox].expand(base: workspace_path, home: true)
     end
 
+    # The engine hands the agent inbox paths for stored media and transcripts,
+    # so an allowlist that omits the inbox hands out unreadable pointers.
+    def filesystem_roots : Array(String)
+      roots = tools.try(&.filesystem.try(&.roots)) || [] of String
+      return roots if roots.empty? || roots.includes?(media.inbox)
+      roots + [media.inbox]
+    end
+
     def transcription_source : TranscriptionConfig::Source?
       return nil unless transcription.enabled?
 
       pinned = transcription.provider
       if own_key = transcription.own_key
-        return TranscriptionConfig::Source.new(pinned || TranscriptionConfig::DEFAULT_PROVIDER, own_key, own_key: true)
+        return TranscriptionConfig::Source.new(pinned || TranscriptionConfig::DEFAULT_PROVIDER, own_key, own_key: true, model: transcription.model)
       end
 
       (pinned ? [pinned] : TranscriptionConfig::PROVIDERS).each do |name|
         key = provider_by_name(name).try(&.api_key.presence)
-        return TranscriptionConfig::Source.new(name, key, own_key: false) if key
+        return TranscriptionConfig::Source.new(name, key, own_key: false, model: transcription.model) if key
       end
       nil
     end

--- a/src/autobot/media/types.cr
+++ b/src/autobot/media/types.cr
@@ -24,13 +24,28 @@ module Autobot
         .each_with_object({} of String => String) { |(ext, (_, mime)), map| map[mime] ||= ext }
         .merge({"audio/x-m4a" => ".m4a"})
 
+      AUDIO_PREFIX = "audio/"
+      IMAGE_PREFIX = "image/"
+
+      def self.audio?(mime_type : String?) : Bool
+        normalized(mime_type).starts_with?(AUDIO_PREFIX)
+      end
+
+      def self.image?(mime_type : String?) : Bool
+        normalized(mime_type).starts_with?(IMAGE_PREFIX)
+      end
+
+      private def self.normalized(mime_type : String?) : String
+        mime_type.try(&.split(';').first.strip.downcase) || ""
+      end
+
       def self.for_extension(extension : String) : {String, String}
         BY_EXTENSION[extension.downcase]? || DEFAULT
       end
 
       def self.extension_for(mime_type : String?, fallback : String) : String
         return fallback unless mime_type
-        EXTENSION_BY_MIME[mime_type.split(';').first.strip.downcase]? || fallback
+        EXTENSION_BY_MIME[normalized(mime_type)]? || fallback
       end
     end
   end

--- a/src/autobot/transcriber.cr
+++ b/src/autobot/transcriber.cr
@@ -26,11 +26,11 @@ module Autobot
 
     getter provider : String
 
-    def initialize(@api_key : String, @provider : String = "openai")
+    def initialize(@api_key : String, @provider : String = "openai", @model : String? = nil)
     end
 
     def self.from_config(config : Config::Config) : Transcriber?
-      config.transcription_source.try { |source| new(api_key: source.api_key, provider: source.provider) }
+      config.transcription_source.try { |source| new(api_key: source.api_key, provider: source.provider, model: source.model) }
     end
 
     # Transcribe audio data to text.
@@ -42,7 +42,7 @@ module Autobot
         return nil
       end
 
-      body = build_multipart_body(audio_data, filename, config[:model])
+      body = build_multipart_body(audio_data, filename, @model || config[:model])
       headers = HTTP::Headers{
         "Authorization" => "Bearer #{@api_key}",
         "Content-Type"  => "multipart/form-data; boundary=#{BOUNDARY}",


### PR DESCRIPTION
## Overview

- [x] transcribe a document when its type is audio, so a recording shared as a file is not dropped
- [x] raise the inline transcript limit from 4,000 to 24,000 characters, about half an hour of speech
- [x] add the media inbox to `tools.filesystem.roots` automatically, so the pointer to a truncated transcript is readable
- [x] report the effective roots in `autobot doctor`
- [x] make `transcription.model` configurable, overriding the provider default
- [x] update `docs/configuration.md` and `docs/media.md`

## Why

A 12-minute recording shared to a bot produced a note covering only its first minutes, or no note at all. All three causes sit on the path a file takes when it is *not* a voice note recorded in the chat: it was never transcribed if it arrived as a document, its transcript was cut at five minutes of speech, and the pointer to the full transcript named a path the agent was forbidden to open.