### PR TITLE
fix(mcp): make MCP tool calls that use $ref schemas work

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -70,6 +70,17 @@ MCP servers run as regular child processes (not sandboxed) because they typicall
 - **Response truncation**: Tool results are capped at 50KB to prevent memory issues
 - **No auto-restart**: If a server crashes, its tools return errors until autobot is restarted
 
+## Tool errors
+
+A server reports a failing tool by answering normally with `isError` set. Autobot honours that
+flag: the call becomes a tool error, the agent is told it failed, and the message is logged at
+warning level.
+
+Not every server sets it. Some return the upstream API's error as ordinary content with no flag,
+and autobot cannot tell that apart from a successful answer — the agent reads the error text and
+decides what to do. When a tool looks like it succeeded but nothing changed, check what the agent
+was actually told rather than trusting the absence of a warning in the log.
+
 ## Troubleshooting
 
 ### Server fails to start

--- a/spec/autobot/mcp/proxy_tool_spec.cr
+++ b/spec/autobot/mcp/proxy_tool_spec.cr
@@ -1,5 +1,29 @@
 require "../../spec_helper"
 
+private class FakeClient < Autobot::Mcp::Client
+  def initialize(@result : Autobot::Mcp::Client::CallResult, @running : Bool = true)
+    super(server_name: "test", command: "echo")
+  end
+
+  def alive? : Bool
+    @running
+  end
+
+  def call_tool(name : String, arguments : Hash(String, JSON::Any)) : Autobot::Mcp::Client::CallResult
+    @result
+  end
+end
+
+private def proxy_for(result : Autobot::Mcp::Client::CallResult) : Autobot::Mcp::ProxyTool
+  Autobot::Mcp::ProxyTool.new(
+    client: FakeClient.new(result),
+    remote_name: "search",
+    name: "mcp_test_search",
+    description: "[test] Search",
+    parameters: Autobot::Tools::ToolSchema.new,
+  )
+end
+
 describe Autobot::Config::McpServerConfig do
   it "deserializes from YAML" do
     config = Autobot::Config::McpServerConfig.from_yaml(<<-YAML
@@ -183,6 +207,25 @@ describe Autobot::Mcp::ProxyTool do
 
       proxy.validate_params({"q" => JSON::Any.new("ok")}).should be_empty
       proxy.validate_params({"q" => JSON.parse(%({"a":1}))}).should_not be_empty
+    end
+  end
+
+  describe "#execute" do
+    it "passes a successful call through" do
+      result = proxy_for(Autobot::Mcp::Client::CallResult.new("ok", failed: false))
+        .execute({} of String => JSON::Any)
+
+      result.success?.should be_true
+      result.content.should eq("ok")
+    end
+
+    it "reports a tool that answered with isError" do
+      result = proxy_for(Autobot::Mcp::Client::CallResult.new("body.parent should be an object", failed: true))
+        .execute({} of String => JSON::Any)
+
+      result.success?.should be_false
+      result.error?.should be_true
+      result.content.should eq("body.parent should be an object")
     end
   end
 

--- a/spec/autobot/mcp/proxy_tool_spec.cr
+++ b/spec/autobot/mcp/proxy_tool_spec.cr
@@ -167,6 +167,25 @@ describe Autobot::Mcp::ProxyTool do
     end
   end
 
+  describe "schema conversion" do
+    it "leaves a property untyped when a branch is a $ref" do
+      tool_json = JSON.parse(%({"name":"post","description":"Post","inputSchema":{"type":"object","properties":{"parent":{"anyOf":[{"$ref":"#/$defs/parentRequest"},{"type":"string"}]}},"required":["parent"]}}))
+      proxy = Autobot::Mcp::ProxyTool.from_mcp_tool(Autobot::Mcp::Client.new(server_name: "test", command: "echo"), tool_json)
+
+      object = JSON.parse(%({"type":"data_source_id","data_source_id":"abc"}))
+      proxy.validate_params({"parent" => object}).should be_empty
+      proxy.validate_params({"parent" => JSON::Any.new("abc")}).should be_empty
+    end
+
+    it "still narrows a property that declares one type" do
+      tool_json = JSON.parse(%({"name":"post","description":"Post","inputSchema":{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}}))
+      proxy = Autobot::Mcp::ProxyTool.from_mcp_tool(Autobot::Mcp::Client.new(server_name: "test", command: "echo"), tool_json)
+
+      proxy.validate_params({"q" => JSON::Any.new("ok")}).should be_empty
+      proxy.validate_params({"q" => JSON.parse(%({"a":1}))}).should_not be_empty
+    end
+  end
+
   describe "#to_schema" do
     it "uses raw input schema when available" do
       tool_json = JSON.parse(%({"name":"search","description":"Search things","inputSchema":{"type":"object","properties":{"q":{"type":"string","description":"query"}},"required":["q"]}}))

--- a/src/autobot/mcp/client.cr
+++ b/src/autobot/mcp/client.cr
@@ -21,6 +21,14 @@ module Autobot
       MAX_RESPONSE_SIZE = 50_000
       ALLOWED_HOST_VARS = {"PATH", "HOME", "LANG"}
 
+      # A tools/call outcome. MCP reports a failing tool as a normal response
+      # carrying `isError`, so the flag has to travel with the content.
+      record CallResult, content : String, failed : Bool do
+        def success? : Bool
+          !failed
+        end
+      end
+
       getter server_name : String
 
       @process : Process?
@@ -107,7 +115,7 @@ module Autobot
 
       # Calls a tool on the MCP server and returns the text content.
       # Result is truncated at `MAX_RESPONSE_SIZE` bytes.
-      def call_tool(name : String, arguments : Hash(String, JSON::Any)) : String
+      def call_tool(name : String, arguments : Hash(String, JSON::Any)) : CallResult
         params = {
           "name"      => JSON::Any.new(name),
           "arguments" => JSON::Any.new(arguments),
@@ -116,10 +124,14 @@ module Autobot
 
         if error = response["error"]?
           message = error["message"]?.try(&.as_s?) || "Unknown MCP error"
-          return "Error: #{message}"
+          return CallResult.new("Error: #{message}", failed: true)
         end
 
-        extract_content(response)
+        CallResult.new(extract_content(response), failed: tool_failed?(response))
+      end
+
+      private def tool_failed?(response : JSON::Any) : Bool
+        response["result"]?.try(&.["isError"]?).try(&.as_bool?) || false
       end
 
       private def wait_for_termination(process : Process) : Nil

--- a/src/autobot/mcp/proxy_tool.cr
+++ b/src/autobot/mcp/proxy_tool.cr
@@ -37,7 +37,10 @@ module Autobot
         end
 
         result = @client.call_tool(@remote_name, params)
-        Tools::ToolResult.success(result)
+        return Tools::ToolResult.success(result.content) if result.success?
+
+        Log.warn { "MCP tool #{@name} returned an error: #{result.content}" }
+        Tools::ToolResult.error(result.content)
       rescue ex
         Log.error { "MCP tool #{@name} failed: #{ex.message}" }
         Tools::ToolResult.error("MCP tool error: #{ex.message}")

--- a/src/autobot/mcp/proxy_tool.cr
+++ b/src/autobot/mcp/proxy_tool.cr
@@ -141,12 +141,25 @@ module Autobot
       end
 
       private def self.resolve_type(prop : JSON::Any) : String
+        return Tools::PropertySchema::ANY if opaque?(prop)
+
         types = declared_types(prop).select { |type| Tools::Tool::VALID_SCHEMA_TYPES.includes?(type) }.uniq!
         case types.size
         when 0 then "string"
         when 1 then types.first
         else        Tools::PropertySchema::ANY
         end
+      end
+
+      # A `$ref` names a definition this converter does not resolve. Narrowing to
+      # the branches it can read would reject values the server accepts.
+      private def self.opaque?(prop : JSON::Any) : Bool
+        return true if prop["$ref"]?
+
+        branches = (prop["anyOf"]? || prop["oneOf"]?).try(&.as_a?)
+        return false unless branches
+
+        branches.any? { |branch| opaque?(branch) }
       end
 
       private def self.declared_types(prop : JSON::Any) : Array(String)


### PR DESCRIPTION
## Overview

- [x] keep a `$ref`-backed parameter untyped instead of narrowing it to the one branch that names a type
- [x] surface a tool that answers with `isError` as a tool error, and log it
- [x] document in `docs/mcp.md` that a server returning an upstream error as plain content still reads as success

## Why

The memo bot could not write anything to Notion. Every `API-post-page` failed, and the agent reported that the tool "only accepts `parent` as a string".

That message was autobot's own. The Notion MCP server declares `parent` as:

```json
{"anyOf": [{"$ref": "#/$defs/parentRequest"}, {"type": "string"}]}
```

`convert_schema` reads only the branches that name a type, so `parent` became `string`. `validate_params` then rejected the correct object at `registry.cr:106` and the call never left autobot. Verified against the real server: the object shape creates the page, a bare string is refused by Notion with `body.parent should be an object`.

The second commit is separate and smaller: a failing MCP tool answers with `isError` on an otherwise normal response, and the proxy was wrapping every response as a success — so a failed call looked like a successful one to both the agent and the log. Note this would *not* have caught the bug above; the Notion server returns Notion's error as plain content with no flag, which stays indistinguishable from success. That limitation is now documented rather than hidden.