### PR TITLE
fix: repair four faults found in the fleet logs

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -251,8 +251,8 @@ LLM generates file (exec tool) -> message(content, file_path) -> Read & base64 e
 | `.gif` | animation | `sendAnimation` |
 | `.mp4` | video | `sendDocument` |
 | `.pdf` | document | `sendDocument` |
-| `.ogg` | voice | `sendVoice` |
-| `.mp3`, `.m4a`, `.wav`, `.webm` | audio | `sendAudio` |
+| `.ogg`, `.oga` | voice | `sendVoice` |
+| `.mp3`, `.m4a`, `.wav`, `.flac`, `.webm` | audio | `sendAudio` |
 | `.txt` | document | `sendDocument` |
 | Other | document | `sendDocument` |
 

--- a/spec/autobot/channels/telegram_html_spec.cr
+++ b/spec/autobot/channels/telegram_html_spec.cr
@@ -194,6 +194,14 @@ describe Autobot::Channels::MarkdownToTelegramHTML do
       Autobot::Channels::MarkdownToTelegramHTML.split_message("short").should eq(["short"])
     end
 
+    it "yields no chunk when there is nothing to send" do
+      Autobot::Channels::MarkdownToTelegramHTML.split_message("").should be_empty
+      Autobot::Channels::MarkdownToTelegramHTML.split_message(" \n\t ").should be_empty
+      Autobot::Channels::MarkdownToTelegramHTML.split_message(
+        Autobot::Channels::MarkdownToTelegramHTML.convert("---")
+      ).should be_empty
+    end
+
     it "splits long messages by paragraphs" do
       paragraph = "a" * 2000
       text = "#{paragraph}\n\n#{paragraph}\n\n#{paragraph}"

--- a/spec/autobot/channels/telegram_media_spec.cr
+++ b/spec/autobot/channels/telegram_media_spec.cr
@@ -54,6 +54,15 @@ describe Autobot::Channels::TelegramMedia do
       transcriber.calls.should eq(["audio.ogg"])
     end
 
+    it "names the upload after a real container when the mime type is unknown" do
+      transcriber = FakeTranscriber.new
+      msg = message(%({"voice": {"file_id": "v2", "mime_type": "audio/opus", "duration": 3}}))
+
+      build_media(transcriber).extract(msg, typed_text: false)
+
+      transcriber.calls.should eq(["audio.ogg"])
+    end
+
     it "falls back to a placeholder without a transcriber" do
       media = build_media
 
@@ -124,6 +133,15 @@ describe Autobot::Channels::TelegramMedia do
       attachments.first.mime_type.should eq("audio/mp4")
       attachments.first.name.should eq("New Recording 6.m4a")
       transcriber.calls.should eq(["audio.m4a"])
+    end
+
+    it "names the upload after a real container when the mime type is unknown" do
+      transcriber = FakeTranscriber.new
+      msg = message(%({"audio": {"file_id": "a4", "mime_type": "audio/basic"}}))
+
+      build_media(transcriber).extract(msg, typed_text: false)
+
+      transcriber.calls.should eq(["audio.mp3"])
     end
 
     it "prefers the file name extension over a conflicting mime type" do

--- a/spec/autobot/cron/service_spec.cr
+++ b/spec/autobot/cron/service_spec.cr
@@ -10,6 +10,26 @@ describe Autobot::Cron::Service do
     FileUtils.rm_rf(tmp) if tmp
   end
 
+  it "creates the store private and then leaves its permissions alone" do
+    tmp = TestHelper.tmp_dir
+    store_path = tmp / "cron.json"
+    service = Autobot::Cron::Service.new(store_path: store_path)
+
+    schedule = Autobot::Cron::CronSchedule.new(
+      kind: Autobot::Cron::ScheduleKind::Every,
+      every_ms: 60000_i64
+    )
+    service.add_job(name: "first", schedule: schedule, message: "one")
+    File.info(store_path).permissions.should eq(File::Permissions.new(0o600))
+
+    File.chmod(store_path, 0o660)
+    service.add_job(name: "second", schedule: schedule, message: "two")
+
+    File.info(store_path).permissions.should eq(File::Permissions.new(0o660))
+  ensure
+    FileUtils.rm_rf(tmp) if tmp
+  end
+
   it "adds a recurring job" do
     tmp = TestHelper.tmp_dir
     service = Autobot::Cron::Service.new(store_path: tmp / "cron.json")

--- a/spec/autobot/media/types_spec.cr
+++ b/spec/autobot/media/types_spec.cr
@@ -12,6 +12,20 @@ describe Autobot::Media::Types do
     end
   end
 
+  describe ".extension_for" do
+    it "maps mime aliases onto a real container extension" do
+      Autobot::Media::Types.extension_for("audio/opus", ".bin").should eq(".ogg")
+      Autobot::Media::Types.extension_for("audio/x-wav", ".bin").should eq(".wav")
+      Autobot::Media::Types.extension_for("audio/x-m4a", ".bin").should eq(".m4a")
+      Autobot::Media::Types.extension_for("audio/ogg", ".bin").should eq(".ogg")
+    end
+
+    it "falls back when the mime is unknown or missing" do
+      Autobot::Media::Types.extension_for("audio/basic", ".mp3").should eq(".mp3")
+      Autobot::Media::Types.extension_for(nil, ".ogg").should eq(".ogg")
+    end
+  end
+
   describe ".audio?" do
     it "recognises audio mime types, parameters and case included" do
       Autobot::Media::Types.audio?("audio/mp4").should be_true

--- a/spec/autobot/tools/message_spec.cr
+++ b/spec/autobot/tools/message_spec.cr
@@ -26,6 +26,18 @@ describe Autobot::Tools::MessageTool do
     sent_messages[0].media?.should be_nil
   end
 
+  it "returns error when content is blank and nothing is attached" do
+    sent_messages = [] of Autobot::Bus::OutboundMessage
+    tool = Autobot::Tools::MessageTool.new
+    tool.set_context("telegram", "123")
+    tool.send_callback = ->(msg : Autobot::Bus::OutboundMessage) { sent_messages << msg; nil }
+
+    result = tool.execute({"content" => JSON::Any.new("  \n ")})
+    result.success?.should be_false
+    result.content.should contain("Message content is empty")
+    sent_messages.should be_empty
+  end
+
   it "returns error when no channel context" do
     tool = Autobot::Tools::MessageTool.new
     tool.send_callback = ->(_msg : Autobot::Bus::OutboundMessage) { nil }

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -92,7 +92,9 @@ module Autobot::Channels
     end
 
     def self.split_message(text : String) : Array(String)
-      return [text] if text.size <= TELEGRAM_MAX_LENGTH
+      if text.size <= TELEGRAM_MAX_LENGTH
+        return text.blank? ? [] of String : [text]
+      end
 
       chunks = [] of String
       code_block_segments(text).each do |segment|
@@ -103,7 +105,7 @@ module Autobot::Channels
           split_by_paragraphs(segment).each { |chunk| chunks << chunk }
         end
       end
-      chunks
+      chunks.reject(&.blank?)
     end
 
     # Splits text into alternating plain and complete <pre><code>...</code></pre>
@@ -398,9 +400,13 @@ module Autobot::Channels
       html = MarkdownToTelegramHTML.convert(message.content)
       html = MarkdownToTelegramHTML.strip_html(html) unless MarkdownToTelegramHTML.valid_html?(html)
 
-      MarkdownToTelegramHTML.split_message(html).each do |chunk|
-        send_html_chunk(message.chat_id, chunk)
+      chunks = MarkdownToTelegramHTML.split_message(html)
+      if chunks.empty?
+        Log.warn { "Nothing to send: formatting left the message empty" }
+        return
       end
+
+      chunks.each { |chunk| send_html_chunk(message.chat_id, chunk) }
     end
 
     private def send_html_chunk(chat_id : String, html : String) : Nil
@@ -410,13 +416,16 @@ module Autobot::Channels
         "parse_mode" => "HTML",
       })
 
-      unless result
-        Log.warn { "HTML parse failed, falling back to plain text" }
-        api_request("sendMessage", {
-          "chat_id" => chat_id,
-          "text"    => MarkdownToTelegramHTML.strip_html(html),
-        })
-      end
+      return if result
+
+      Log.warn { "HTML parse failed, falling back to plain text" }
+      plain = MarkdownToTelegramHTML.strip_html(html)
+      return if plain.blank?
+
+      api_request("sendMessage", {
+        "chat_id" => chat_id,
+        "text"    => plain,
+      })
     end
 
     private def find_sendable_attachment(media : Array(Bus::MediaAttachment)?) : Bus::MediaAttachment?

--- a/src/autobot/channels/telegram_media.cr
+++ b/src/autobot/channels/telegram_media.cr
@@ -48,7 +48,7 @@ module Autobot::Channels
       return {nil, nil} unless voice
 
       bytes = fetch(voice)
-      format = format_of(voice, Bus::MediaAttachment::TYPE_VOICE, "audio/ogg")
+      format = format_of(voice, ".ogg")
       transcript = transcribe(bytes, format[0])
       attachment = build(Bus::MediaAttachment::TYPE_VOICE, voice, origin, format, bytes,
         transcript: spoken ? nil : transcript, transcribed: !transcript.nil?)
@@ -60,7 +60,7 @@ module Autobot::Channels
       return nil unless audio
 
       bytes = fetch(audio)
-      format = format_of(audio, Bus::MediaAttachment::TYPE_AUDIO, "audio/mpeg")
+      format = format_of(audio, ".mp3")
       build(Bus::MediaAttachment::TYPE_AUDIO, audio, origin, format, bytes,
         transcript: transcribe(bytes, format[0]),
         name: string_of(audio, "title") || string_of(audio, "file_name"))
@@ -70,7 +70,7 @@ module Autobot::Channels
       document = msg["document"]?
       return nil unless document
 
-      extension, mime = format = format_of(document, Bus::MediaAttachment::TYPE_DOCUMENT, Media::Types::DEFAULT[1])
+      extension, mime = format = format_of(document, ".bin")
       bytes = fetch(document)
       data = Media::Types.image?(mime) && bytes ? Base64.strict_encode(bytes) : nil
 
@@ -82,13 +82,13 @@ module Autobot::Channels
 
     # The platform file name is the most reliable source of the format; Telegram
     # often omits mime_type, and Whisper rejects a mislabelled extension.
-    private def format_of(node : JSON::Any, type : String, default_mime : String) : {String, String}
+    private def format_of(node : JSON::Any, default_extension : String) : {String, String}
       name_extension = File.extname(string_of(node, "file_name") || "").downcase
       mime = string_of(node, "mime_type")
       return {name_extension, mime || Media::Types.for_extension(name_extension)[1]} unless name_extension.empty?
 
-      mime ||= default_mime
-      {Media::Types.extension_for(mime, ".#{type}"), mime}
+      extension = Media::Types.extension_for(mime, default_extension)
+      {extension, mime || Media::Types.for_extension(extension)[1]}
     end
 
     private def build(type : String, node : JSON::Any, origin : String, format : {String, String}, bytes : Bytes?,

--- a/src/autobot/cron/service.cr
+++ b/src/autobot/cron/service.cr
@@ -278,8 +278,9 @@ module Autobot
           File.chmod(dir, 0o700)
         end
 
+        created = !File.exists?(@store_path)
         File.write(@store_path, s.to_json)
-        File.chmod(@store_path, 0o600)
+        File.chmod(@store_path, 0o600) if created
         @store_mtime = File.info(@store_path).modification_time
       end
 

--- a/src/autobot/media/types.cr
+++ b/src/autobot/media/types.cr
@@ -14,15 +14,27 @@ module Autobot
         ".pdf"  => {"document", "application/pdf"},
         ".txt"  => {"document", "text/plain"},
         ".ogg"  => {"voice", "audio/ogg"},
+        ".oga"  => {"voice", "audio/ogg"},
         ".mp3"  => {"audio", "audio/mpeg"},
         ".m4a"  => {"audio", "audio/mp4"},
         ".wav"  => {"audio", "audio/wav"},
+        ".flac" => {"audio", "audio/flac"},
         ".webm" => {"audio", "audio/webm"},
       }
 
       EXTENSION_BY_MIME = BY_EXTENSION
         .each_with_object({} of String => String) { |(ext, (_, mime)), map| map[mime] ||= ext }
-        .merge({"audio/x-m4a" => ".m4a"})
+        .merge({
+          "audio/x-m4a"    => ".m4a",
+          "audio/mp3"      => ".mp3",
+          "audio/x-mpeg"   => ".mp3",
+          "audio/opus"     => ".ogg",
+          "audio/vorbis"   => ".ogg",
+          "audio/x-wav"    => ".wav",
+          "audio/wave"     => ".wav",
+          "audio/vnd.wave" => ".wav",
+          "audio/x-flac"   => ".flac",
+        })
 
       AUDIO_PREFIX = "audio/"
       IMAGE_PREFIX = "image/"

--- a/src/autobot/tools/message.cr
+++ b/src/autobot/tools/message.cr
@@ -88,6 +88,10 @@ module Autobot
         media = build_media_attachment(params["file_path"]?.try(&.as_s))
         return media if media.is_a?(ToolResult)
 
+        if content.blank? && media.nil?
+          return ToolResult.error("Message content is empty: put the text to send in 'content'")
+        end
+
         msg = Bus::OutboundMessage.new(
           channel: channel,
           chat_id: chat_id,


### PR DESCRIPTION
## Overview

Four faults seen in the journal of a running four-bot fleet, each a silent or repeating failure rather than a crash.

- [x] cron keeps the timer running when the store cannot be chmodded, so no job due in the same wake-up is skipped
- [x] the message tool refuses blank content instead of answering "Message sent" for a message Telegram rejected
- [x] Telegram drops a chunk that Markdown conversion emptied instead of sending it, failing, and failing again as plain text
- [x] an unknown audio mime falls back to a real container extension, so transcription is no longer handed `audio.voice` and answered `Invalid file format`
- [x] `docs/media.md` lists the extensions the media table gained (`.oga`, `.flac`)