### PR TITLE
fix(agent): stop the filler reply landing on top of a tool's own output

### DIFF
--- a/spec/autobot/agent/loop_spec.cr
+++ b/spec/autobot/agent/loop_spec.cr
@@ -18,6 +18,24 @@ class MockProvider < Autobot::Providers::HttpProvider
   end
 end
 
+class SelfDeliveringTool < Autobot::Tools::Tool
+  def name : String
+    "deliver"
+  end
+
+  def description : String
+    "Delivers its own output"
+  end
+
+  def parameters : Autobot::Tools::ToolSchema
+    Autobot::Tools::ToolSchema.new(properties: {} of String => Autobot::Tools::PropertySchema)
+  end
+
+  def execute(params : Hash(String, JSON::Any)) : Autobot::Tools::ToolResult
+    Autobot::Tools::ToolResult.success("# sent")
+  end
+end
+
 # Testable subclass exposing private methods for unit testing.
 class TestableLoop < Autobot::Agent::Loop
   def test_build_cron_prompt(msg : Autobot::Bus::InboundMessage) : String
@@ -390,6 +408,37 @@ describe Autobot::Agent::Loop do
       history[1]["content"].should eq("Sent via message tool")
     ensure
       FileUtils.rm_rf(tmp) if tmp
+    end
+
+    it "stays quiet when a tool answered the turn and the model added nothing" do
+      tmp = TestHelper.tmp_dir
+      sessions = Autobot::Session::Manager.new(tmp)
+      bus = Autobot::Bus::MessageBus.new(capacity: 10)
+      tool_call_resp = %({"choices":[{"message":{"content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"deliver","arguments":"{}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}})
+      empty_resp = %({"choices":[{"message":{"content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}})
+      provider = MockProvider.new(responses: [tool_call_resp, empty_resp])
+      tools = Autobot::Tools::Registry.new
+      tools.register(Autobot::Tools::MessageTool.new)
+      tools.register(SelfDeliveringTool.new)
+
+      loop_inst = TestableLoop.new(
+        bus: bus,
+        provider: provider,
+        workspace: tmp,
+        tools: tools,
+        sessions: sessions,
+        memory_window: 0,
+        sandbox_config: "none"
+      )
+
+      msg = Autobot::Bus::InboundMessage.new(
+        channel: "telegram",
+        sender_id: "user1",
+        chat_id: "chat1",
+        content: "zrucznyj u korystuvanni"
+      )
+
+      loop_inst.test_process_message(msg).should be_nil
     end
 
     it "preserves inbound metadata in outbound response" do

--- a/src/autobot/agent/loop.cr
+++ b/src/autobot/agent/loop.cr
@@ -184,14 +184,18 @@ module Autobot::Agent
 
       @message_tool.try(&.clear_last_sent)
       result = @executor.execute(messages, @tools, session_key: session.key)
-      final_content = result.content.presence || @message_tool.try(&.last_sent_content) || FALLBACK_RESPONSE
+      sent_by_message_tool = @message_tool.try(&.last_sent_content)
+      final_content = result.content.presence || sent_by_message_tool || FALLBACK_RESPONSE
 
       save_to_session(session, @context.render_user_text(msg.content, msg.media?), final_content, result.tools_used)
 
-      # Skip automatic text response if the message tool already sent during this turn
-      return nil if @message_tool.try(&.last_sent_content)
+      return nil if sent_by_message_tool || answered_by_tools?(result)
 
       build_response(msg.channel, msg.chat_id, final_content, msg.metadata)
+    end
+
+    private def answered_by_tools?(result : ToolExecutor::Result) : Bool
+      result.content.presence.nil? && !result.tools_used.empty?
     end
 
     # Route system messages to the appropriate handler.


### PR DESCRIPTION
## Overview

A tool may deliver its own output — and the model then ends the turn with nothing left to say. The loop read that empty completion as a missing answer and sent `I've completed processing but have no response to give.` into the chat, directly under the message the tool had already delivered.

- [x] an empty completion after a turn that ran tools now ends the turn quietly
- [x] `FALLBACK_RESPONSE` is left for the case it was written for — a turn where nothing ran and the model still produced no text

Until #130 this was hidden: the agent called `message` with empty content, the tool reported a phantom send, and the phantom suppressed the filler. Refusing the empty message made the real gap visible.