### PR TITLE
fix(telegram): send script command output as text, not a code block

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -85,7 +85,7 @@ channels:
           description: "Deploy to production"
 ```
 
-**Macros** send the prompt to the LLM. **Scripts** execute a shell command and return the output.
+**Macros** send the prompt to the LLM. **Scripts** execute a shell command and send its output as plain text, exactly as printed: nothing in it is interpreted as formatting, and `<` and `&` are escaped. A script that fails gets `Script failed (exit N):` followed by its stderr.
 
 ## Built-in commands
 

--- a/spec/autobot/channels/telegram_spec.cr
+++ b/spec/autobot/channels/telegram_spec.cr
@@ -614,6 +614,41 @@ describe Autobot::Channels::TelegramChannel do
   end
 
   describe "#execute_script" do
+    it "sends the output as plain text, exactly as printed" do
+      tmp = TestHelper.tmp_dir
+      script_file = tmp / "progress.sh"
+      File.write(script_file, <<-SCRIPT)
+        #!/bin/sh
+        printf '📊 Words: 16 new · **5 due**\n📅 Days: 3/7 <b>\n'
+        SCRIPT
+      File.chmod(script_file, 0o755)
+
+      channel = build_channel
+      channel.test_execute_script(script_file.to_s, "", "123")
+
+      channel.sent_replies.should eq(["📊 Words: 16 new · **5 due**\n📅 Days: 3/7 &lt;b&gt;"])
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
+    it "sends a failed script's stderr as plain text" do
+      tmp = TestHelper.tmp_dir
+      script_file = tmp / "broken.sh"
+      File.write(script_file, <<-SCRIPT)
+        #!/bin/sh
+        echo 'no such <thing>' >&2
+        exit 2
+        SCRIPT
+      File.chmod(script_file, 0o755)
+
+      channel = build_channel
+      channel.test_execute_script(script_file.to_s, "", "123")
+
+      channel.sent_replies.should eq(["Script failed (exit 2):\nno such &lt;thing&gt;"])
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+    end
+
     it "drains large stderr output concurrent with stdout without deadlocking" do
       tmp = TestHelper.tmp_dir
       script_file = tmp / "test_script.sh"

--- a/src/autobot/channels/telegram.cr
+++ b/src/autobot/channels/telegram.cr
@@ -885,10 +885,16 @@ module Autobot::Channels
                end
 
       stop_typing(chat_id)
-      send_reply(chat_id, "<pre>#{MarkdownToTelegramHTML.escape_html(result)}</pre>")
+      send_verbatim(chat_id, result)
     rescue ex
       stop_typing(chat_id)
       send_reply(chat_id, "Error running script")
+    end
+
+    private def send_verbatim(chat_id : String, text : String) : Nil
+      MarkdownToTelegramHTML.split_message(MarkdownToTelegramHTML.escape_html(text.strip)).each do |chunk|
+        send_reply(chat_id, chunk)
+      end
     end
 
     private def validate_script_path(script_path : String) : String?


### PR DESCRIPTION
## Overview

A script command's stdout was wrapped in `<pre>`, so a script that prints chat text — a summary line, a score, a menu — arrived as a monospace block: code font, no wrapping on a phone.

- [x] script output is sent as plain text, exactly as printed and still HTML-escaped — nothing in it is interpreted as formatting, so a script that echoes a user's argument cannot be made to emit a link or markup in the bot's voice
- [x] long output is split like any other message
- [x] a failing script sends its stderr the same way after `Script failed (exit N):`
- [x] `docs/telegram.md` states the contract